### PR TITLE
Fix UserGroupHotRecall local cache panic

### DIFF
--- a/service/recall/user_group_hot_recall.go
+++ b/service/recall/user_group_hot_recall.go
@@ -34,21 +34,19 @@ func (r *UserGroupHotRecall) GetCandidateItems(user *module.User, context *conte
 		case []uint8:
 			itemIds := strings.Split(string(itemStr), ",")
 			for _, id := range itemIds {
-				item := &module.Item{
-					Id:         module.ItemId(id),
-					ItemType:   r.itemType,
-					RetrieveId: r.modelName,
-				}
+				item := module.NewItem(id)
+				item.ItemType = r.itemType
+				item.RetrieveId = r.modelName
+
 				ret = append(ret, item)
 			}
 		case string:
 			itemIds := strings.Split(itemStr, ",")
 			for _, id := range itemIds {
-				item := &module.Item{
-					Id:         module.ItemId(id),
-					ItemType:   r.itemType,
-					RetrieveId: r.modelName,
-				}
+				item := module.NewItem(id)
+				item.ItemType = r.itemType
+				item.RetrieveId = r.modelName
+
 				ret = append(ret, item)
 			}
 		default:


### PR DESCRIPTION
修复分组热门召回使用缓存数据时，没有正确初始化 Item 引起的 panic