### PR TITLE
Fix register hooks and adjust CompletelyFairCountFilter

### DIFF
--- a/filter/completely_fair_count_filter.go
+++ b/filter/completely_fair_count_filter.go
@@ -32,8 +32,12 @@ func (f *CompletelyFairCountFilter) Filter(filterData *FilterData) error {
 func (f *CompletelyFairCountFilter) doFilter(filterData *FilterData) error {
 	start := time.Now()
 	items := filterData.Data.([]*module.Item)
-	if len(items) <= f.retainNum {
+	retainNum := f.retainNum
+
+	if len(items) == 0 {
 		return nil
+	} else if len(items) <= retainNum {
+		retainNum = len(items)
 	}
 
 	newItems := make([]*module.Item, 0, 200)
@@ -63,7 +67,7 @@ func (f *CompletelyFairCountFilter) doFilter(filterData *FilterData) error {
 		recallNamesCount = len(recallNames)
 	)
 
-	for count < f.retainNum {
+	for count < retainNum {
 		i := count % recallNamesCount
 
 		itemList := recallToItemMap[recallNames[i]]

--- a/filter/completely_fair_count_filter_test.go
+++ b/filter/completely_fair_count_filter_test.go
@@ -1,0 +1,82 @@
+package filter
+
+import (
+	"fmt"
+	"github.com/alibaba/pairec/v2/context"
+	"github.com/alibaba/pairec/v2/module"
+	"github.com/alibaba/pairec/v2/recconf"
+	"testing"
+)
+
+func TestCompletelyFairCountFilter(t *testing.T) {
+	fairCountFilter := NewCompletelyFairCountFilter(recconf.FilterConfig{
+		RetainNum: 10,
+	})
+
+	user := module.NewUser("user_1")
+
+	var items []*module.Item
+
+	for i := 0; i < 10; i++ {
+		item := module.NewItem(fmt.Sprintf("item_a_%d", i))
+		item.Score = float64(i)
+		item.RetrieveId = "recall1"
+		items = append(items, item)
+	}
+
+	for i := 0; i < 10; i++ {
+		item := module.NewItem(fmt.Sprintf("item_b_%d", i))
+		item.RetrieveId = "recall2"
+		items = append(items, item)
+	}
+
+	filterData := &FilterData{
+		Context: &context.RecommendContext{
+			RecommendId: "1",
+		},
+		Data: items,
+		User: user,
+	}
+
+	err := fairCountFilter.Filter(filterData)
+	if err != nil {
+		t.Error(err)
+	}
+	filterItems := filterData.Data.([]*module.Item)
+
+	if len(filterItems) != 10 {
+		t.Error("len(items) != 10", len(filterItems))
+	}
+	recallNames := []string{"recall1", "recall2"}
+	for i, item := range filterItems {
+		if item.RetrieveId != recallNames[i%len(recallNames)] {
+			t.Errorf("item.RetrieveId != %s, %v", recallNames[i%len(recallNames)], item)
+		}
+	}
+
+	filterData = &FilterData{
+		Context: &context.RecommendContext{
+			RecommendId: "1",
+		},
+		Data: items,
+		User: user,
+	}
+	fairCountFilter2 := NewCompletelyFairCountFilter(recconf.FilterConfig{
+		RetainNum: 100,
+	})
+	err = fairCountFilter2.Filter(filterData)
+	if err != nil {
+		t.Error(err)
+	}
+	filterItems = filterData.Data.([]*module.Item)
+
+	if len(filterItems) != 20 {
+		t.Error("len(items) != 20", len(filterItems))
+	}
+
+	for i, item := range filterItems {
+		if item.RetrieveId != recallNames[i%len(recallNames)] {
+			t.Errorf("item.RetrieveId != %s, %v", recallNames[i%len(recallNames)], item)
+		}
+	}
+}

--- a/service/hook/recommend.go
+++ b/service/hook/recommend.go
@@ -22,14 +22,11 @@ func RegisterRecommendCleanHook(name string, hf RecommendCleanHookFunc) {
 	defer mu.Unlock()
 
 	if index, exist := RecommendCleanHookMap[name]; exist {
-		var hookfuncs []RecommendCleanHookFunc
-		for i, hookfunc := range RecommendCleanHooks {
-			if i != index {
-				hookfuncs = append(hookfuncs, hookfunc)
-			}
+		if index >= 0 && index < len(RecommendCleanHooks) {
+			RecommendCleanHooks[index] = hf
 		}
-		RecommendCleanHooks = hookfuncs
+	} else {
+		AddRecommendCleanHook(hf)
+		RecommendCleanHookMap[name] = len(RecommendCleanHooks) - 1
 	}
-	AddRecommendCleanHook(hf)
-	RecommendCleanHookMap[name] = len(RecommendCleanHooks) - 1
 }


### PR DESCRIPTION
1. 修复注册 hook 时存在的 bug，解决更新曝光过滤后 hook 丢失的问题
2. 调整公平过滤，即使不足保留数量，也可以使得召回结果以公平的顺序排列