### PR TITLE
feat: add timestamp() function to expr feature generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 require (
 	fortio.org/assert v1.2.1
 	github.com/alibabacloud-go/opensearch-util v1.0.1
-	github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.0
+	github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260408073641-a6396965e76c
 	github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260323112208-51b86e8512e0
 	github.com/aliyun/credentials-go v1.4.8
 	github.com/apache/calcite-avatica-go/v5 v5.0.0

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/aliyun/aliyun-log-go-sdk v0.1.27 h1:fXtaOAcdR3DsqN9GZkfJue8B2Dba0TV+8
 github.com/aliyun/aliyun-log-go-sdk v0.1.27/go.mod h1:aBG0R+MWRTgvlIODQkz+a3/RM9bQYKsmSbKdbIx4vpc=
 github.com/aliyun/aliyun-odps-go-sdk/arrow v0.0.1 h1:jSMfOm0fpc83+YersEbXhYG7/4o1z0u698FiacPD77o=
 github.com/aliyun/aliyun-odps-go-sdk/arrow v0.0.1/go.mod h1:ki4zr1YK8ehW1rQxMFoAVTnjZeRNcSbVNyJxJZqR9i4=
-github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.0 h1:YwrZjAM6J2utdU/xlWnK4Hyb52ESPWE1NtWfeoisNJI=
-github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.0/go.mod h1:1nP9jGmFj7jSmeSKCTdMkxdpByhPGnPQE0Im1Eyyd6Q=
+github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260408073641-a6396965e76c h1:Supe8At2J+FcIs7VYOCsiXh7/MHvzGf0kD0OuhfeHyg=
+github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260408073641-a6396965e76c/go.mod h1:1nP9jGmFj7jSmeSKCTdMkxdpByhPGnPQE0Im1Eyyd6Q=
 github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260323112208-51b86e8512e0 h1:/vetP0u6yEA6yT+16nkB5ADSHFH6c3nHzf9tsIXXWt4=
 github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260323112208-51b86e8512e0/go.mod h1:TjHkSEFlBAPhzp5sT5rheXSorgIdKxVh/2MVG2qHXmA=
 github.com/aliyun/aliyun-tablestore-go-sdk v1.7.7 h1:+d/mcgaxx1jaWtFN2WrBHy4XeM9IK5gmZvbbpVkhqHE=

--- a/service/feature/normalizer_test.go
+++ b/service/feature/normalizer_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
 	"fortio.org/assert"
 	"github.com/alibaba/pairec/v2/context"
@@ -252,6 +253,19 @@ func TestExpressionFunctionNormalizer(t *testing.T) {
 
 		assert.Equal(t, utils.ToInt(result, 0), 1067)
 	})
+	t.Run("timestamp", func(t *testing.T) {
+		// timestamp() returns unix timestamp in seconds
+		normalizer := NewExpressionNormalizer("timestamp()")
+		result := normalizer.Apply(map[string]interface{}{})
+		now := time.Now().Unix()
+		assert.Equal(t, result, float64(now))
+
+		// timestamp("ms") returns unix timestamp in milliseconds
+		normalizer = NewExpressionNormalizer("timestamp('ms')")
+		result = normalizer.Apply(map[string]interface{}{})
+		nowMs := time.Now().UnixMilli()
+		assert.Equal(t, result, float64(nowMs))
+	})
 }
 
 func TestExprFunctionNormalizer(t *testing.T) {
@@ -399,5 +413,18 @@ func TestExprFunctionNormalizer(t *testing.T) {
 		result = normalizer.Apply(map[string]interface{}{"arr": []float64{0.1, 0.2, 0.3, 0.4}})
 
 		assert.Equal(t, result.(float64), float64(0.4))
+	})
+	t.Run("timestamp", func(t *testing.T) {
+		// timestamp() returns unix timestamp in seconds
+		normalizer := NewExprNormalizer("timestamp()")
+		result := normalizer.Apply(map[string]interface{}{})
+		now := time.Now().Unix()
+		assert.Equal(t, result, float64(now))
+
+		// timestamp("ms") returns unix timestamp in milliseconds
+		normalizer = NewExprNormalizer("timestamp('ms')")
+		result = normalizer.Apply(map[string]interface{}{})
+		nowMs := time.Now().UnixMilli()
+		assert.Equal(t, result, float64(nowMs))
 	})
 }

--- a/service/feature/normalizer_test.go
+++ b/service/feature/normalizer_test.go
@@ -256,15 +256,17 @@ func TestExpressionFunctionNormalizer(t *testing.T) {
 	t.Run("timestamp", func(t *testing.T) {
 		// timestamp() returns unix timestamp in seconds
 		normalizer := NewExpressionNormalizer("timestamp()")
+		before := time.Now().Unix()
 		result := normalizer.Apply(map[string]interface{}{})
-		now := time.Now().Unix()
-		assert.Equal(t, result, float64(now))
+		after := time.Now().Unix()
+		assert.True(t, result.(float64) >= float64(before) && result.(float64) <= float64(after))
 
 		// timestamp("ms") returns unix timestamp in milliseconds
 		normalizer = NewExpressionNormalizer("timestamp('ms')")
+		beforeMs := time.Now().UnixMilli()
 		result = normalizer.Apply(map[string]interface{}{})
-		nowMs := time.Now().UnixMilli()
-		assert.Equal(t, result, float64(nowMs))
+		afterMs := time.Now().UnixMilli()
+		assert.True(t, result.(float64) >= float64(beforeMs) && result.(float64) <= float64(afterMs))
 	})
 }
 
@@ -417,14 +419,16 @@ func TestExprFunctionNormalizer(t *testing.T) {
 	t.Run("timestamp", func(t *testing.T) {
 		// timestamp() returns unix timestamp in seconds
 		normalizer := NewExprNormalizer("timestamp()")
+		before := time.Now().Unix()
 		result := normalizer.Apply(map[string]interface{}{})
-		now := time.Now().Unix()
-		assert.Equal(t, result, float64(now))
+		after := time.Now().Unix()
+		assert.True(t, result.(float64) >= float64(before) && result.(float64) <= float64(after))
 
 		// timestamp("ms") returns unix timestamp in milliseconds
 		normalizer = NewExprNormalizer("timestamp('ms')")
+		beforeMs := time.Now().UnixMilli()
 		result = normalizer.Apply(map[string]interface{}{})
-		nowMs := time.Now().UnixMilli()
-		assert.Equal(t, result, float64(nowMs))
+		afterMs := time.Now().UnixMilli()
+		assert.True(t, result.(float64) >= float64(beforeMs) && result.(float64) <= float64(afterMs))
 	})
 }

--- a/utils/govaluate_functions.go
+++ b/utils/govaluate_functions.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/Knetic/govaluate"
 	"github.com/cespare/xxhash/v2"
@@ -256,7 +257,17 @@ var (
 			return distance, nil
 		},
 
-		"maxIndex": func(args ...interface{}) (interface{}, error) {
+		"timestamp": func(args ...interface{}) (interface{}, error) {
+				now := time.Now().Unix()
+				if len(args) > 0 {
+					unit := strings.ToLower(ToString(args[0], ""))
+					if unit == "ms" || unit == "millisecond" || unit == "milliseconds" {
+						return float64(time.Now().UnixMilli()), nil
+					}
+				}
+				return float64(now), nil
+			},
+			"maxIndex": func(args ...interface{}) (interface{}, error) {
 			if len(args) != 1 {
 				return nil, errors.New("maxIndex: expects exactly one argument")
 			}

--- a/utils/govaluate_functions.go
+++ b/utils/govaluate_functions.go
@@ -258,16 +258,16 @@ var (
 		},
 
 		"timestamp": func(args ...interface{}) (interface{}, error) {
-				now := time.Now().Unix()
-				if len(args) > 0 {
-					unit := strings.ToLower(ToString(args[0], ""))
-					if unit == "ms" || unit == "millisecond" || unit == "milliseconds" {
-						return float64(time.Now().UnixMilli()), nil
-					}
+			now := time.Now()
+			if len(args) > 0 {
+				unit := strings.ToLower(ToString(args[0], ""))
+				if unit == "ms" || unit == "millisecond" || unit == "milliseconds" {
+					return float64(now.UnixMilli()), nil
 				}
-				return float64(now), nil
-			},
-			"maxIndex": func(args ...interface{}) (interface{}, error) {
+			}
+			return float64(now.Unix()), nil
+		},
+		"maxIndex": func(args ...interface{}) (interface{}, error) {
 			if len(args) != 1 {
 				return nil, errors.New("maxIndex: expects exactly one argument")
 			}


### PR DESCRIPTION
## Summary
- 在 expr 特征生成表达式中新增 `timestamp()` 内置函数，支持生成当前时间戳
- `timestamp()` 返回秒级 unix 时间戳，`timestamp("ms")` 返回毫秒级 unix 时间戳
- govaluate (`expression` normalizer) 和 expr-lang (`expr` normalizer) 两种引擎均支持

## Changes
- `utils/govaluate_functions.go`: 在 functions map 中新增 `timestamp` 函数，接受可选参数区分秒/毫秒
- `service/feature/normalizer_test.go`: 为 `TestExpressionFunctionNormalizer` 和 `TestExprFunctionNormalizer` 各新增 timestamp 测试用例

## Test plan
- [x] `TestExpressionFunctionNormalizer/timestamp` 通过（govaluate 引擎）
- [x] `TestExprFunctionNormalizer/timestamp` 通过（expr 引擎）
- [x] `go test ./service/feature/` 全部通过，无回归

## Configuration example
```json
// 秒级时间戳
{ "Normalizer": "expr", "Expression": "timestamp()" }

// 毫秒级时间戳
{ "Normalizer": "expr", "Expression": "timestamp('ms')" }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)