### PR TITLE
feat: add GenerateItemDataExpr support for exposure filter item data generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ commands/tmp
 docs/
 .vscode/
 parse_pb_log.py
+.claude

--- a/module/user_item_exposure_be_dao.go
+++ b/module/user_item_exposure_be_dao.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alibaba/pairec/v2/log"
 	"github.com/alibaba/pairec/v2/recconf"
 	be "github.com/aliyun/aliyun-be-go-sdk"
+	"github.com/expr-lang/expr/vm"
 )
 
 type User2ItemExposureBeDao struct {
@@ -18,6 +19,7 @@ type User2ItemExposureBeDao struct {
 	userIdName               string
 	itemIdName               string
 	generateItemDataFuncName string
+	generateItemProgram      *vm.Program
 	writeLogExcludeScenes    map[string]bool
 	clearLogScene            string
 }
@@ -37,6 +39,7 @@ func NewUser2ItemExposureBeDao(config recconf.FilterConfig) *User2ItemExposureBe
 	}
 	dao.beClient = client.BeClient
 	dao.table = config.DaoConf.BeTableName
+	dao.generateItemProgram = compileItemDataExpr(config.GenerateItemDataExpr)
 
 	for _, scene := range config.WriteLogExcludeScenes {
 		dao.writeLogExcludeScenes[scene] = true
@@ -60,7 +63,7 @@ func (d *User2ItemExposureBeDao) LogHistory(user *User, items []*Item, context *
 	createTime := time.Now().Unix()
 	var contents []map[string]string
 	for _, item := range items {
-		itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
 		contents = append(contents, map[string]string{
 			d.userIdName: uid,
 			d.itemIdName: itemData,

--- a/module/user_item_exposure_be_dao.go
+++ b/module/user_item_exposure_be_dao.go
@@ -63,7 +63,7 @@ func (d *User2ItemExposureBeDao) LogHistory(user *User, items []*Item, context *
 	createTime := time.Now().Unix()
 	var contents []map[string]string
 	for _, item := range items {
-		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item, context)
 		contents = append(contents, map[string]string{
 			d.userIdName: uid,
 			d.itemIdName: itemData,

--- a/module/user_item_exposure_dao.go
+++ b/module/user_item_exposure_dao.go
@@ -50,13 +50,17 @@ func compileItemDataExpr(exprStr string) *vm.Program {
 }
 
 // getItemData generates item data using expr program if available, otherwise falls back to registered function.
-func getItemData(funcName string, program *vm.Program, uid UID, item *Item) string {
+func getItemData(funcName string, program *vm.Program, uid UID, item *Item, ctx *context.RecommendContext) string {
 	if program != nil {
 		m := map[string]any{
-			"uid":        string(uid),
-			"item_id":    string(item.Id),
-			"properties": item.GetProperties(),
-			"sprintf":    fmt.Sprintf,
+			"uid":     string(uid),
+			"item_id": string(item.Id),
+			"item":    item.GetProperties(),
+			"sprintf": fmt.Sprintf,
+			"context": map[string]any{
+				"item_id":  utils.ToString(ctx.GetParameter("item_id"), ""),
+				"features": ctx.GetParameter("features"),
+			},
 		}
 		if output, err := expr.Run(program, m); err != nil {
 			log.Error(fmt.Sprintf("module=getItemData\tuid=%s\titem_id=%s\terr=%v", uid, item.Id, err))

--- a/module/user_item_exposure_dao.go
+++ b/module/user_item_exposure_dao.go
@@ -4,8 +4,12 @@ import (
 	"fmt"
 
 	"github.com/alibaba/pairec/v2/context"
+	"github.com/alibaba/pairec/v2/log"
 	"github.com/alibaba/pairec/v2/recconf"
 	"github.com/alibaba/pairec/v2/service/hook"
+	"github.com/alibaba/pairec/v2/utils"
+	"github.com/expr-lang/expr"
+	"github.com/expr-lang/expr/vm"
 )
 
 type GenerateItemDataFunc func(uid UID, item *Item) string
@@ -31,6 +35,38 @@ func getGenerateItemDataFunc(name string) GenerateItemDataFunc {
 // default function
 func defaultGenerateItemDataFunc(uid UID, item *Item) string {
 	return string(item.Id)
+}
+
+// compileItemDataExpr compiles the item data expr expression at init time.
+func compileItemDataExpr(exprStr string) *vm.Program {
+	if exprStr == "" {
+		return nil
+	}
+	p, err := expr.Compile(exprStr)
+	if err != nil {
+		panic(fmt.Sprintf("compile GenerateItemDataExpr error: %v", err))
+	}
+	return p
+}
+
+// getItemData generates item data using expr program if available, otherwise falls back to registered function.
+func getItemData(funcName string, program *vm.Program, uid UID, item *Item) string {
+	if program != nil {
+		m := map[string]any{
+			"uid":        string(uid),
+			"item_id":    string(item.Id),
+			"properties": item.GetProperties(),
+			"sprintf":    fmt.Sprintf,
+		}
+		if output, err := expr.Run(program, m); err != nil {
+			log.Error(fmt.Sprintf("module=getItemData\tuid=%s\titem_id=%s\terr=%v", uid, item.Id, err))
+		} else {
+			if str := utils.ToString(output, ""); str != "" {
+				return str
+			}
+		}
+	}
+	return getGenerateItemDataFunc(funcName)(uid, item)
 }
 
 type User2ItemExposureDao interface {

--- a/module/user_item_exposure_featurestore_dao.go
+++ b/module/user_item_exposure_featurestore_dao.go
@@ -19,6 +19,7 @@ type User2ItemExposureFeatureStoreDao struct {
 	table                    string
 	timeInterval             int64 //  second
 	generateItemDataFuncName string
+	generateItemProgram      *vm.Program
 	writeLogExcludeScenes    map[string]bool
 	clearLogScene            string
 	onlyLogUserExposeFlag    bool
@@ -54,6 +55,7 @@ func NewUser2ItemExposureFeatureStoreDao(config recconf.FilterConfig) *User2Item
 			dao.generateUserProgram = p
 		}
 	}
+	dao.generateItemProgram = compileItemDataExpr(config.GenerateItemDataExpr)
 	return dao
 }
 
@@ -88,7 +90,7 @@ func (d *User2ItemExposureFeatureStoreDao) LogHistory(user *User, items []*Item,
 	ts := start.Unix() - ttl + d.timeInterval
 
 	for _, item := range items {
-		itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
 		request.Kvs = append(request.Kvs, &fdbserverpb.KVData{
 			Key:   userData,
 			Value: []byte(itemData),
@@ -125,7 +127,7 @@ func (d *User2ItemExposureFeatureStoreDao) FilterByHistory(uid UID, items []*Ite
 
 	request.Key = userData
 	for _, item := range items {
-		itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(uid, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
 		request.Items = append(request.Items, itemData)
 	}
 

--- a/module/user_item_exposure_featurestore_dao.go
+++ b/module/user_item_exposure_featurestore_dao.go
@@ -90,7 +90,7 @@ func (d *User2ItemExposureFeatureStoreDao) LogHistory(user *User, items []*Item,
 	ts := start.Unix() - ttl + d.timeInterval
 
 	for _, item := range items {
-		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item, context)
 		request.Kvs = append(request.Kvs, &fdbserverpb.KVData{
 			Key:   userData,
 			Value: []byte(itemData),
@@ -127,7 +127,7 @@ func (d *User2ItemExposureFeatureStoreDao) FilterByHistory(uid UID, items []*Ite
 
 	request.Key = userData
 	for _, item := range items {
-		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item, context)
 		request.Items = append(request.Items, itemData)
 	}
 

--- a/module/user_item_exposure_graph_dao.go
+++ b/module/user_item_exposure_graph_dao.go
@@ -92,7 +92,7 @@ func (d *User2ItemExposureGraphDao) LogHistory(user *User, items []*Item, contex
 	//将 item 数据写入 item 节点
 	var ret string
 	for _, item := range items {
-		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item, context)
 		ret = ret + "," + itemData
 	}
 	ret = ret[1:]
@@ -157,7 +157,7 @@ func (d *User2ItemExposureGraphDao) FilterByHistory(uid UID, items []*Item, cont
 	}
 
 	for _, item := range items {
-		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item, context)
 		if _, ok := fiterIds[itemData]; !ok {
 			ret = append(ret, item)
 		}

--- a/module/user_item_exposure_graph_dao.go
+++ b/module/user_item_exposure_graph_dao.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alibaba/pairec/v2/log"
 	"github.com/alibaba/pairec/v2/recconf"
 	igraph "github.com/aliyun/aliyun-igraph-go-sdk"
+	"github.com/expr-lang/expr/vm"
 )
 
 type User2ItemExposureGraphDao struct {
@@ -23,6 +24,7 @@ type User2ItemExposureGraphDao struct {
 	maxItems                 int
 	timeInterval             int //  second
 	generateItemDataFuncName string
+	generateItemProgram      *vm.Program
 	writeLogExcludeScenes    map[string]bool
 	clearLogScene            string
 }
@@ -57,6 +59,7 @@ func NewUser2ItemExposureGraphDao(config recconf.FilterConfig) *User2ItemExposur
 	for _, scene := range config.WriteLogExcludeScenes {
 		dao.writeLogExcludeScenes[scene] = true
 	}
+	dao.generateItemProgram = compileItemDataExpr(config.GenerateItemDataExpr)
 	return dao
 }
 
@@ -89,7 +92,7 @@ func (d *User2ItemExposureGraphDao) LogHistory(user *User, items []*Item, contex
 	//将 item 数据写入 item 节点
 	var ret string
 	for _, item := range items {
-		itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
 		ret = ret + "," + itemData
 	}
 	ret = ret[1:]
@@ -154,7 +157,7 @@ func (d *User2ItemExposureGraphDao) FilterByHistory(uid UID, items []*Item, cont
 	}
 
 	for _, item := range items {
-		itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(uid, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
 		if _, ok := fiterIds[itemData]; !ok {
 			ret = append(ret, item)
 		}

--- a/module/user_item_exposure_hologres_dao.go
+++ b/module/user_item_exposure_hologres_dao.go
@@ -128,7 +128,7 @@ func (d *User2ItemExposureHologresDao) LogHistory(user *User, items []*Item, con
 	createTime := time.Now().Unix()
 	var ret string
 	for _, item := range items {
-		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item, context)
 		ret = ret + "," + itemData
 	}
 	ret = ret[1:]
@@ -204,7 +204,7 @@ func (d *User2ItemExposureHologresDao) FilterByHistory(uid UID, items []*Item, c
 	}
 	if d.onlyLogUserExposeFlag {
 		for _, item := range items {
-			itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
+			itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item, context)
 			if _, ok := fiterIds[itemData]; ok {
 				item.AddProperty("_is_exposure_", 1)
 			}
@@ -213,7 +213,7 @@ func (d *User2ItemExposureHologresDao) FilterByHistory(uid UID, items []*Item, c
 		ret = items
 	} else {
 		for _, item := range items {
-			itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
+			itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item, context)
 			if _, ok := fiterIds[itemData]; !ok {
 				ret = append(ret, item)
 			}

--- a/module/user_item_exposure_hologres_dao.go
+++ b/module/user_item_exposure_hologres_dao.go
@@ -48,6 +48,7 @@ type User2ItemExposureHologresDao struct {
 	insertStmt               *sql.Stmt
 	selectStmt               *sql.Stmt
 	generateItemDataFuncName string
+	generateItemProgram      *vm.Program
 	writeLogExcludeScenes    map[string]bool
 	clearLogScene            string
 	onlyLogUserExposeFlag    bool
@@ -87,6 +88,7 @@ func NewUser2ItemExposureHologresDao(config recconf.FilterConfig) *User2ItemExpo
 			dao.generateUserProgram = p
 		}
 	}
+	dao.generateItemProgram = compileItemDataExpr(config.GenerateItemDataExpr)
 	return dao
 }
 
@@ -126,7 +128,7 @@ func (d *User2ItemExposureHologresDao) LogHistory(user *User, items []*Item, con
 	createTime := time.Now().Unix()
 	var ret string
 	for _, item := range items {
-		itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
 		ret = ret + "," + itemData
 	}
 	ret = ret[1:]
@@ -202,7 +204,7 @@ func (d *User2ItemExposureHologresDao) FilterByHistory(uid UID, items []*Item, c
 	}
 	if d.onlyLogUserExposeFlag {
 		for _, item := range items {
-			itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(uid, item)
+			itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
 			if _, ok := fiterIds[itemData]; ok {
 				item.AddProperty("_is_exposure_", 1)
 			}
@@ -211,7 +213,7 @@ func (d *User2ItemExposureHologresDao) FilterByHistory(uid UID, items []*Item, c
 		ret = items
 	} else {
 		for _, item := range items {
-			itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(uid, item)
+			itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
 			if _, ok := fiterIds[itemData]; !ok {
 				ret = append(ret, item)
 			}

--- a/module/user_item_exposure_hologres_v2_dao.go
+++ b/module/user_item_exposure_hologres_v2_dao.go
@@ -71,6 +71,7 @@ type User2ItemExposureHologresV2Dao struct {
 	insertStmt               *sql.Stmt
 	selectStmt               *sql.Stmt
 	generateItemDataFuncName string
+	generateItemProgram      *vm.Program
 	writeLogExcludeScenes    map[string]bool
 	clearLogScene            string
 	onlyLogUserExposeFlag    bool
@@ -113,6 +114,7 @@ func NewUser2ItemExposureHologresV2Dao(config recconf.FilterConfig) *User2ItemEx
 			dao.generateUserProgram = p
 		}
 	}
+	dao.generateItemProgram = compileItemDataExpr(config.GenerateItemDataExpr)
 	return dao
 }
 
@@ -152,7 +154,7 @@ func (d *User2ItemExposureHologresV2Dao) LogHistory(user *User, items []*Item, c
 	createTime := time.Now().Unix()
 	var ret string
 	for _, item := range items {
-		itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
 		ret = ret + "," + itemData
 	}
 	ret = ret[1:]
@@ -225,7 +227,7 @@ func (d *User2ItemExposureHologresV2Dao) FilterByHistory(uid UID, items []*Item,
 	}
 	if d.onlyLogUserExposeFlag {
 		for _, item := range items {
-			itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(uid, item)
+			itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
 			if _, ok := fiterIds[itemData]; ok {
 				item.AddProperty("_is_exposure_", 1)
 			}
@@ -234,7 +236,7 @@ func (d *User2ItemExposureHologresV2Dao) FilterByHistory(uid UID, items []*Item,
 		ret = items
 	} else {
 		for _, item := range items {
-			itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(uid, item)
+			itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
 			if _, ok := fiterIds[itemData]; !ok {
 				ret = append(ret, item)
 			}

--- a/module/user_item_exposure_hologres_v2_dao.go
+++ b/module/user_item_exposure_hologres_v2_dao.go
@@ -154,7 +154,7 @@ func (d *User2ItemExposureHologresV2Dao) LogHistory(user *User, items []*Item, c
 	createTime := time.Now().Unix()
 	var ret string
 	for _, item := range items {
-		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item, context)
 		ret = ret + "," + itemData
 	}
 	ret = ret[1:]
@@ -227,7 +227,7 @@ func (d *User2ItemExposureHologresV2Dao) FilterByHistory(uid UID, items []*Item,
 	}
 	if d.onlyLogUserExposeFlag {
 		for _, item := range items {
-			itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
+			itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item, context)
 			if _, ok := fiterIds[itemData]; ok {
 				item.AddProperty("_is_exposure_", 1)
 			}
@@ -236,7 +236,7 @@ func (d *User2ItemExposureHologresV2Dao) FilterByHistory(uid UID, items []*Item,
 		ret = items
 	} else {
 		for _, item := range items {
-			itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
+			itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item, context)
 			if _, ok := fiterIds[itemData]; !ok {
 				ret = append(ret, item)
 			}

--- a/module/user_item_exposure_recallengine_dao.go
+++ b/module/user_item_exposure_recallengine_dao.go
@@ -83,7 +83,7 @@ func (d *User2ItemExposureRecallEngineDao) LogHistory(user *User, items []*Item,
 
 	writeRequest := re.WriteRequest{}
 	for _, item := range items {
-		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item, context)
 		writeRequest.Content = append(writeRequest.Content, map[string]any{
 			"item_id":   itemData,
 			"timestamp": ts,

--- a/module/user_item_exposure_recallengine_dao.go
+++ b/module/user_item_exposure_recallengine_dao.go
@@ -19,6 +19,7 @@ type User2ItemExposureRecallEngineDao struct {
 	table                    string
 	timeInterval             int64 //  second
 	generateItemDataFuncName string
+	generateItemProgram      *vm.Program
 	writeLogExcludeScenes    map[string]bool
 	clearLogScene            string
 	onlyLogUserExposeFlag    bool
@@ -53,6 +54,7 @@ func NewUser2ItemExposureRecallEngineDao(config recconf.FilterConfig) *User2Item
 			dao.generateUserProgram = p
 		}
 	}
+	dao.generateItemProgram = compileItemDataExpr(config.GenerateItemDataExpr)
 	return dao
 }
 
@@ -81,7 +83,7 @@ func (d *User2ItemExposureRecallEngineDao) LogHistory(user *User, items []*Item,
 
 	writeRequest := re.WriteRequest{}
 	for _, item := range items {
-		itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
 		writeRequest.Content = append(writeRequest.Content, map[string]any{
 			"item_id":   itemData,
 			"timestamp": ts,

--- a/module/user_item_exposure_tablestore_dao.go
+++ b/module/user_item_exposure_tablestore_dao.go
@@ -64,7 +64,7 @@ func (d *User2ItemExposureTableStoreDao) LogHistory(user *User, items []*Item, c
 	uid := string(user.Id)
 	idList := make([]string, 0)
 	for _, item := range items {
-		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item, context)
 		idList = append(idList, itemData)
 	}
 
@@ -138,7 +138,7 @@ func (d *User2ItemExposureTableStoreDao) FilterByHistory(uid UID, items []*Item,
 	}
 
 	for _, item := range items {
-		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item, context)
 		if _, ok := fiterIds[itemData]; !ok {
 			ret = append(ret, item)
 		}

--- a/module/user_item_exposure_tablestore_dao.go
+++ b/module/user_item_exposure_tablestore_dao.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alibaba/pairec/v2/persist/tablestoredb"
 	"github.com/alibaba/pairec/v2/recconf"
 	"github.com/aliyun/aliyun-tablestore-go-sdk/tablestore"
+	"github.com/expr-lang/expr/vm"
 )
 
 type User2ItemExposureTableStoreDao struct {
@@ -18,6 +19,7 @@ type User2ItemExposureTableStoreDao struct {
 	maxItems                 int32
 	timeInterval             int //  second
 	generateItemDataFuncName string
+	generateItemProgram      *vm.Program
 	writeLogExcludeScenes    map[string]bool
 	clearLogScene            string
 }
@@ -48,6 +50,7 @@ func NewUser2ItemExposureTableStoreDao(config recconf.FilterConfig) *User2ItemEx
 	for _, scene := range config.WriteLogExcludeScenes {
 		dao.writeLogExcludeScenes[scene] = true
 	}
+	dao.generateItemProgram = compileItemDataExpr(config.GenerateItemDataExpr)
 
 	return dao
 }
@@ -61,7 +64,7 @@ func (d *User2ItemExposureTableStoreDao) LogHistory(user *User, items []*Item, c
 	uid := string(user.Id)
 	idList := make([]string, 0)
 	for _, item := range items {
-		itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(user.Id, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, user.Id, item)
 		idList = append(idList, itemData)
 	}
 
@@ -135,7 +138,7 @@ func (d *User2ItemExposureTableStoreDao) FilterByHistory(uid UID, items []*Item,
 	}
 
 	for _, item := range items {
-		itemData := getGenerateItemDataFunc(d.generateItemDataFuncName)(uid, item)
+		itemData := getItemData(d.generateItemDataFuncName, d.generateItemProgram, uid, item)
 		if _, ok := fiterIds[itemData]; !ok {
 			ret = append(ret, item)
 		}

--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -775,6 +775,7 @@ type FilterConfig struct {
 	GroupWeightDimensionLimit map[string]int
 	WriteLogExcludeScenes     []string
 	GenerateItemDataFuncName  string
+	GenerateItemDataExpr      string
 	GenerateUserDataExpr      string
 	AdjustCountConfs          []AdjustCountConfig
 	ItemStateDaoConf          ItemStateDaoConfig


### PR DESCRIPTION
## Summary

Add expr expression support for generating custom item data in exposure filter, similar to the existing `GenerateUserDataExpr` for user data generation. This allows configuring item data generation via expressions without code changes.

## Changes
- **recconf/recconf.go**: Add `GenerateItemDataExpr` config field to `FilterConfig`
- **module/user_item_exposure_dao.go**: Add centralized `compileItemDataExpr()` and `getItemData()` helper functions
- **7 DAO files**: Add `generateItemProgram` field and use `getItemData()` for expr-based item data generation (Hologres, Hologres V2, FeatureStore, RecallEngine, BE, TableStore, Graph)

## Expr Environment Variables
| Variable | Type | Description |
|----------|------|-------------|
| `uid` | string | User ID |
| `item_id` | string | Item ID |
| `properties` | map[string]any | Item properties |
| `sprintf` | func | Format function |

## Config Example
```json
{
  "GenerateItemDataExpr": "sprintf(\"%s_%s\", item_id, properties[\"category\"])"
}
```

## Backward Compatibility
Fully backward compatible. When `GenerateItemDataExpr` is empty, falls back to the original `GenerateItemDataFuncName` function-based approach.

Aone: #81458660