### PR TITLE
fix: sync cold start recall itemIds with featurestore scan result

### DIFF
--- a/module/cold_start_recall_featurestore_dao.go
+++ b/module/cold_start_recall_featurestore_dao.go
@@ -216,14 +216,20 @@ func (d *ColdStartRecallFeatureStoreDao) ListItemsByUser(user *User, context *co
 				time.Sleep(10 * time.Second)
 			}
 			if err != nil {
+				// Preserve previous itemIds on transient errors to avoid flapping.
 				log.Error(fmt.Sprintf("module=ColdStartRecallFeatureStoreDao\terror=%v", err))
 				return
 			}
+
+			// Always overwrite itemIds with the latest full scan result,
+			// including empty results, so that the recall pool stays in sync
+			// with the underlying featureview. This prevents stale items from
+			// being recalled after the source data has been cleared.
+			d.itemIds = ids
 			if len(ids) == 0 {
+				log.Warning(fmt.Sprintf("module=ColdStartRecallFeatureStoreDao\trecallName=%s\tmsg=scan returned empty result, itemIds cleared", d.recallName))
 				return
 			}
-
-			d.itemIds = ids
 			go d.fetchItemData(d.itemIds)
 			log.Info(fmt.Sprintf("module=ColdStartRecallFeatureStoreDao\tmsg=load item\tsize=%d", len(d.itemIds)))
 		}()


### PR DESCRIPTION
## Summary

Fix cold start recall not syncing with featureview data when underlying source is cleared. When offline featureview (fdb) had no data, the in-memory cache still kept old items and kept recalling stale results.

## Root Cause

In `ColdStartRecallFeatureStoreDao`, the background 60-minute rescan treated empty scan results as a no-op and returned early, leaving `d.itemIds` pointing at stale data.

## Fix

Always overwrite `d.itemIds` with the latest full scan result (including empty), so the recall pool stays in sync with the underlying featureview. Transient errors (after 5 retries) still preserve the previous itemIds to avoid flapping.

This fix applies to both Batch and Stream featureview types.

## Effect

- **Batch**: Once the featureview is cleared, the next rescan will clear `d.itemIds`; `d.cache` entries expire via their 1-minute TTL, and stale items stop being recalled.
- **Stream**: The nil-channel rescan now carries delete semantics, resolving the historical blind spot where channel-based updates only append.

## Verification

- `go build ./...` passes
- `go vet ./module/...` clean

## Related

- Aone: #81976426