### PR TITLE
feat: add name field to sort and recall info logs

### DIFF
--- a/service/recall/user_custom_recall.go
+++ b/service/recall/user_custom_recall.go
@@ -48,7 +48,7 @@ func (r *UserCustomRecall) GetCandidateItems(user *module.User, context *context
 				item.RetrieveId = r.modelName
 				ret = append(ret, item)
 			}
-			log.Info(fmt.Sprintf("requestId=%s\tmodule=UserCustomRecall\tcount=%d\tcost=%d", context.RecommendId, len(ret), utils.CostTime(start)))
+			log.Info(fmt.Sprintf("requestId=%s\tmodule=UserCustomRecall\tname=%s\tfrom=cache\tcount=%d\tcost=%d", context.RecommendId, r.modelName, len(ret), utils.CostTime(start)))
 			return
 		}
 	}

--- a/service/recall/user_group_hot_recall.go
+++ b/service/recall/user_group_hot_recall.go
@@ -73,7 +73,7 @@ func (r *UserGroupHotRecall) GetCandidateItems(user *module.User, context *conte
 		}
 
 		if len(ret) > 0 {
-			log.Info(fmt.Sprintf("requestId=%s\tmodule=UserGroupHotRecall\tfrom=cache\tcount=%d\tcost=%d", context.RecommendId, len(ret), utils.CostTime(start)))
+			log.Info(fmt.Sprintf("requestId=%s\tmodule=UserGroupHotRecall\tname=%s\tfrom=cache\tcount=%d\tcost=%d", context.RecommendId, r.modelName, len(ret), utils.CostTime(start)))
 			return
 		}
 	}

--- a/sort/boost_score_by_weight.go
+++ b/sort/boost_score_by_weight.go
@@ -2,17 +2,20 @@ package sort
 
 import (
 	"errors"
+	"time"
+
 	"github.com/alibaba/pairec/v2/module"
 	"github.com/alibaba/pairec/v2/recconf"
-	"time"
 )
 
 type BoostScoreByWeight struct {
+	name                  string
 	BoostScoreByWeightDao module.BoostScoreByWeightDao
 }
 
 func NewBoostScoreByWeight(config recconf.SortConfig) *BoostScoreByWeight {
 	boostScoreByWeight := BoostScoreByWeight{
+		name:                  config.Name,
 		BoostScoreByWeightDao: module.NewBoostScoreByWeightDao(config),
 	}
 
@@ -34,6 +37,6 @@ func (s *BoostScoreByWeight) doSort(sortData *SortData) error {
 	resultItems := s.BoostScoreByWeightDao.Sort(items)
 
 	sortData.Data = resultItems
-	sortInfoLog(sortData, "BoostScoreByWeight", len(resultItems), start)
+	sortInfoLogWithName(sortData, "BoostScoreByWeight", s.name, len(resultItems), start)
 	return nil
 }

--- a/sort/diversity_rule_sort.go
+++ b/sort/diversity_rule_sort.go
@@ -278,7 +278,7 @@ func (s *DiversityRuleSort) doSort(sortData *SortData) error {
 	result = append(result, excludeItems...)
 
 	sortData.Data = result
-	sortInfoLog(sortData, "DiversityRuleSort", len(result), start)
+	sortInfoLogWithName(sortData, "DiversityRuleSort", s.name, len(result), start)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Add `name` field to info logs of sort/recall operators that were missing it, aligning with the conventions already used by other operators (e.g. `DistinctIdSort`, `BoostScoreSort`, `VectorRecall`, etc.).

## Changes

### Sort
- **DiversityRuleSort** ([sort/diversity_rule_sort.go](sort/diversity_rule_sort.go)): switch from `sortInfoLog` to `sortInfoLogWithName`, emitting the configured sort name.
- **BoostScoreByWeight** ([sort/boost_score_by_weight.go](sort/boost_score_by_weight.go)): add a `name` field to the struct populated from `config.Name`, and switch the info log to `sortInfoLogWithName`.

### Recall (cache-hit branches)
- **UserGroupHotRecall** ([service/recall/user_group_hot_recall.go](service/recall/user_group_hot_recall.go)): include \`name=%s\` (\`r.modelName\`) in the cache-hit info log.
- **UserCustomRecall** ([service/recall/user_custom_recall.go](service/recall/user_custom_recall.go)): include \`name=%s\` and \`from=cache\` in the cache-hit info log, matching the style of \`UserGroupHotRecall\` / \`ItemCollaborativeFilterRecall\`.

## Verification
- \`go build ./...\` ✅
- \`go vet ./sort/ ./service/recall/ ./filter/\` ✅

## Example log output

Before:
\`\`\`
module=DiversityRuleSort	count=520	cost=0
\`\`\`

After:
\`\`\`
module=DiversityRuleSort	name=NewItem14Diversity	count=520	cost=0
\`\`\`