### PR TITLE
fix: guard callback path against empty item list panic

### DIFF
--- a/callback_hook.go
+++ b/callback_hook.go
@@ -43,6 +43,16 @@ func CallBackHookFunc(context *context.RecommendContext, params ...any) {
 	user := params[0].(*module.User)
 	items := params[1].([]*module.Item)
 
+	// Skip when upstream produced no candidate items (e.g. filters dropped
+	// everything). The HTTP self-call path used to be guarded by
+	// CallBackController.CheckParameter which rejects empty item_list with
+	// "recommend item list not empty"; SendDirect bypasses that check, so
+	// without this early return an empty-items request would reach
+	// CallBackService.Rank and panic on a nil algoData.
+	if len(items) == 0 {
+		return
+	}
+
 	if callbackConfig.ItemSize > 0 && len(items) > callbackConfig.ItemSize {
 		items = items[:callbackConfig.ItemSize]
 	}

--- a/callback_hook_test.go
+++ b/callback_hook_test.go
@@ -1,0 +1,57 @@
+package pairec
+
+import (
+	"testing"
+
+	"github.com/alibaba/pairec/v2/context"
+	"github.com/alibaba/pairec/v2/module"
+	"github.com/alibaba/pairec/v2/recconf"
+)
+
+// hookStubParam implements context.IParam for tests, returning a fixed scene.
+type hookStubParam struct {
+	scene string
+}
+
+func (s *hookStubParam) GetParameter(name string) interface{} {
+	if name == "scene" {
+		return s.scene
+	}
+	return nil
+}
+
+// TestCallBackHookFunc_EmptyItems_EarlyReturn verifies the hook returns
+// cleanly when the recommend pipeline produced zero candidate items, instead
+// of constructing a CallBackParam with an empty ItemList and forwarding it to
+// the worker via web.SendDirect. The downstream worker (CallBackService.Rank)
+// previously panicked on a nil algoData when given an empty item list, see
+// service/call_back_service_test.go:TestCallBackService_Rank_EmptyItems.
+//
+// To prove the early return fires before any further work, this test passes
+// a nil *module.User as params[0]. The hook accesses user.MakeUserFeatures
+// only after the items length check; if the guard were missing, the nil user
+// would be dereferenced and the test would panic.
+func TestCallBackHookFunc_EmptyItems_EarlyReturn(t *testing.T) {
+	const scene = "test_scene"
+
+	ctx := context.NewRecommendContext()
+	ctx.Param = &hookStubParam{scene: scene}
+	ctx.RecommendId = "test-req-id"
+	ctx.Debug = true // bypass the !Debug && !callbackFlag short-circuit
+	ctx.Config = &recconf.RecommendConfig{
+		CallBackConfs: map[string]recconf.CallBackConfig{
+			scene: {},
+		},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("CallBackHookFunc panicked with empty items: %v", r)
+		}
+	}()
+
+	var nilUser *module.User // intentional: proves we return before user access
+	emptyItems := []*module.Item{}
+
+	CallBackHookFunc(ctx, nilUser, emptyItems)
+}

--- a/doc/code_reviews/2026-06-01-fix-callback-empty-itemlist-panic.md
+++ b/doc/code_reviews/2026-06-01-fix-callback-empty-itemlist-panic.md
@@ -1,0 +1,80 @@
+# Code Review — fix/callback-empty-itemlist-panic
+
+- **Date:** 2026-06-01
+- **Branch:** `fix/callback-empty-itemlist-panic`
+- **Base SHA:** `9b2259d` (origin/master)
+- **Initial HEAD SHA:** `51b9dcf` (review subject)
+- **Reviewer:** superpowers:code-reviewer subagent
+
+## Verdict
+
+**Ship it** — "可合并但建议改进". Two-layer defensive fix is correct, well-commented, and the regression tests reproduce the production panic exactly. One Important suggestion (I2) closes the semantic boundary at `SendDirect`.
+
+## What was reviewed
+
+Fix for production panic at `service/call_back_service.go:228` (`addr=0x28`):
+
+```
+panic: runtime error: invalid memory address or nil pointer dereference
+goroutine 19512 [running]:
+github.com/alibaba/pairec/v2/service.(*CallBackService).Rank.func1(...)
+```
+
+Root cause: commit `6e10261` replaced HTTP self-call with `web.SendDirect`, bypassing `CallBackController.CheckParameter`'s empty-ItemList rejection. `Rank()` assumed items non-empty.
+
+Two-layer fix:
+1. `callback_hook.go` — early return when `len(items) == 0`
+2. `service/call_back_service.go` — explicit `if algoData == nil { return }` guard
+
+## Strengths
+
+- Correct root-cause framing; comments name the missing `CheckParameter` invariant
+- Defense in depth — Layer 1 fixes known caller, Layer 2 defends function itself
+- Hook-side guard placement is optimal (after type asserts, before sampling)
+- Regression tests verifiably catch the bug when fix removed:
+  - Rank test reproduces production trace byte-for-byte (`addr=0x28`, `:228`)
+  - Hook test uses nil-user trick to prove early return fires before user access
+
+## Issues & Resolution
+
+### Critical
+None.
+
+### Important
+
+**I2 — SendDirect should own the invariant itself** *(addressed in fixup)*
+The original design hole is in `SendDirect`, not its callers. Adding the guard there makes it spec-equivalent to the HTTP entry's `CheckParameter`, immune to future caller mistakes.
+
+→ **Fix applied** in `web/callback_controller_handler.go:73-81`. Added `TestSendDirect_EmptyItemList` for symmetry with `TestSendDirect_NilParam`.
+
+**I1 — Rank regression test relies on process termination, not `recover()`** *(addressed in fixup)*
+The `defer recover()` in `TestCallBackService_Rank_EmptyItems` cannot catch the spawned-goroutine panic. The regression is detected only by Go's `runtime.fatalpanic` crashing the test binary. If anyone later adds `defer recover()` inside the goroutine, this test silently starts passing with the bug intact.
+
+→ **Note added** in `service/call_back_service_test.go` explaining the backstop nature and pointing to a future refactor (extract goroutine body for synchronous testability).
+
+### Minor
+
+**M1 — Log level / wording in Rank** *(addressed in fixup)*
+With Layers 1 & 3 in place, the Layer-2 branch only fires on caller misuse → upgraded `log.Info` → `log.Warning`, message changed to `algoData is nil, skipping rank fan-out`.
+
+**M2 — Comment verbosity is appropriate** *(no change)*
+Verbose comments are justified — the bug exists because an earlier commit silently lost an invariant. Paper trail is the right call.
+
+**M3 — Side-effect analysis (no change)**
+Verified the early-return skips only the goroutine fan-out + `wg.Wait()` + timing log. No metric/side-effect lost. `AddFeatures` (`service/rank/algo_data.go:104-118`) unconditionally appends → `HasFeatures()` is always true for non-empty `rankItems`, so no false positives.
+
+**M4 — Hook test only covers Debug path** *(no change)*
+Both `Debug` and `AutoInvokeCallBack` paths converge on the same `len(items) == 0` check. Adding a second test for `callbackFlag` path duplicates coverage without raising assurance.
+
+**M5 — Stub type duplication across packages** *(no change)*
+`hookStubParam` and `stubParam` are identical but live in different packages. A shared `testutil` package isn't worth it for two stubs.
+
+## Files reviewed
+
+- `callback_hook.go`
+- `callback_hook_test.go`
+- `service/call_back_service.go`
+- `service/call_back_service_test.go`
+- `web/callback_controller_handler.go` (for I2 context)
+- `web/callback_controller.go` (for `CheckParameter` reference)
+- `service/rank/algo_data.go` (for `HasFeatures`/`AddFeatures` side-effect analysis)

--- a/service/call_back_service.go
+++ b/service/call_back_service.go
@@ -192,6 +192,17 @@ func (r *CallBackService) Rank(context *context.RecommendContext) {
 		}
 	}
 
+	// Explicit guard: when no item carried features (e.g. r.Items is empty
+	// or every item returned an empty feature map), algoGenerator.HasFeatures
+	// is false and algoData stays nil. The goroutine loop below dereferences
+	// algoData, so without this guard we hit a nil pointer panic at
+	// algoData.GetFeatures(). Returning here also avoids spawning goroutines
+	// that have no work to do.
+	if algoData == nil {
+		log.Info(fmt.Sprintf("requestId=%s\tmodule=callback\tevent=Rank\tmsg=skip rank, no features available", context.RecommendId))
+		return
+	}
+
 	var wg sync.WaitGroup
 	for _, algoName := range rankConfig.RankAlgoList {
 		wg.Add(1)

--- a/service/call_back_service.go
+++ b/service/call_back_service.go
@@ -198,8 +198,12 @@ func (r *CallBackService) Rank(context *context.RecommendContext) {
 	// algoData, so without this guard we hit a nil pointer panic at
 	// algoData.GetFeatures(). Returning here also avoids spawning goroutines
 	// that have no work to do.
+	//
+	// With the upstream guards in callback_hook.go and web.SendDirect, this
+	// branch is only reachable when a future caller bypasses both, i.e.
+	// misuse, so log at Warning level for ops triage.
 	if algoData == nil {
-		log.Info(fmt.Sprintf("requestId=%s\tmodule=callback\tevent=Rank\tmsg=skip rank, no features available", context.RecommendId))
+		log.Warning(fmt.Sprintf("requestId=%s\tmodule=callback\tevent=Rank\tmsg=algoData is nil, skipping rank fan-out", context.RecommendId))
 		return
 	}
 

--- a/service/call_back_service_test.go
+++ b/service/call_back_service_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/alibaba/pairec/v2/context"
+	"github.com/alibaba/pairec/v2/module"
+	"github.com/alibaba/pairec/v2/recconf"
+)
+
+// stubParam implements context.IParam for tests, returning a fixed scene name.
+type stubParam struct {
+	scene string
+}
+
+func (s *stubParam) GetParameter(name string) interface{} {
+	if name == "scene" {
+		return s.scene
+	}
+	return nil
+}
+
+// TestCallBackService_Rank_EmptyItems verifies that Rank() does not panic when
+// the candidate item list is empty. The HTTP self-call entry used to be
+// guarded by CallBackController.CheckParameter ("recommend item list not
+// empty"), but the SendDirect entry bypasses that check. Without an explicit
+// nil guard inside Rank(), algoGenerator.HasFeatures() returns false,
+// algoData stays nil, and the goroutine loop dereferences it ->
+// "invalid memory address or nil pointer dereference" at
+// algoData.GetFeatures().
+func TestCallBackService_Rank_EmptyItems(t *testing.T) {
+	const scene = "test_scene"
+
+	ctx := context.NewRecommendContext()
+	ctx.Param = &stubParam{scene: scene}
+	ctx.RecommendId = "test-req-id"
+	ctx.Config = &recconf.RecommendConfig{
+		CallBackConfs: map[string]recconf.CallBackConfig{
+			scene: {
+				RankConf: recconf.RankConfig{
+					// Non-empty so we skip the early "no algo" return at
+					// the top of Rank() and reach the algoData branch.
+					RankAlgoList: []string{"dummy_algo"},
+				},
+			},
+		},
+	}
+
+	svc := NewCallBackService()
+	svc.User = module.NewUser("test_user")
+	svc.Items = nil // the regression: zero candidates
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Rank() panicked with empty items: %v", r)
+		}
+	}()
+
+	svc.Rank(ctx)
+}

--- a/service/call_back_service_test.go
+++ b/service/call_back_service_test.go
@@ -50,6 +50,16 @@ func TestCallBackService_Rank_EmptyItems(t *testing.T) {
 	svc.User = module.NewUser("test_user")
 	svc.Items = nil // the regression: zero candidates
 
+	// NOTE: The recover() below is a *backstop only*. The real bug surfaces
+	// inside a goroutine spawned by Rank() (call_back_service.go:209) and
+	// cannot be caught by recover in the parent goroutine. The regression is
+	// instead detected by the test binary crashing with an unrecovered
+	// goroutine panic, which Go's test framework reports as FAIL. If anyone
+	// later wraps the spawned goroutine in its own defer/recover, this test
+	// will silently start passing even with the bug back in place. In that
+	// case, refactor Rank() so the nil-algoData branch is synchronously
+	// observable (e.g. extract the goroutine body into a method that returns
+	// an error) and assert on that instead.
 	defer func() {
 		if r := recover(); r != nil {
 			t.Fatalf("Rank() panicked with empty items: %v", r)

--- a/web/callback_controller_handler.go
+++ b/web/callback_controller_handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"fmt"
 	"sync"
 
 	plog "github.com/alibaba/pairec/v2/log"
@@ -67,6 +68,16 @@ func SendDirect(param *CallBackParam) {
 	// keeps the misuse visible without taking down the request.
 	if param == nil {
 		plog.Error("event=SendDirect\terror=nil param")
+		return
+	}
+
+	// Mirror the empty ItemList rejection that CallBackController.CheckParameter
+	// enforces on the HTTP /api/callback path (web/callback_controller.go:109).
+	// Without this, an empty ItemList reaches CallBackService.Rank and panics
+	// at a nil algoData. Owning the invariant here makes SendDirect spec-
+	// equivalent to the HTTP entry, so any future caller is automatically safe.
+	if len(param.ItemList) == 0 {
+		plog.Info(fmt.Sprintf("event=SendDirect\trequestId=%s\tmsg=empty item list, skip", param.RequestId))
 		return
 	}
 

--- a/web/callback_controller_handler.go
+++ b/web/callback_controller_handler.go
@@ -77,7 +77,7 @@ func SendDirect(param *CallBackParam) {
 	// at a nil algoData. Owning the invariant here makes SendDirect spec-
 	// equivalent to the HTTP entry, so any future caller is automatically safe.
 	if len(param.ItemList) == 0 {
-		plog.Info(fmt.Sprintf("event=SendDirect\trequestId=%s\tmsg=empty item list, skip", param.RequestId))
+		plog.Info(fmt.Sprintf("requestId=%s\tevent=SendDirect\tmsg=empty item list, skip", param.RequestId))
 		return
 	}
 

--- a/web/callback_controller_handler_test.go
+++ b/web/callback_controller_handler_test.go
@@ -18,3 +18,28 @@ func TestSendDirect_NilParam(t *testing.T) {
 	// Should return cleanly without enqueueing anything.
 	SendDirect(nil)
 }
+
+// TestSendDirect_EmptyItemList verifies SendDirect rejects a CallBackParam
+// with an empty ItemList, mirroring CallBackController.CheckParameter on
+// the HTTP /api/callback path. Without this guard, the worker would call
+// CallBackService.Rank with no items, which would dereference a nil
+// algoData and crash the process (see
+// service/call_back_service_test.go:TestCallBackService_Rank_EmptyItems).
+//
+// The handler channel is never reachable from this test (it would require
+// initializing the global handler), so the assertion here is "no panic
+// and clean return". A passing test means SendDirect returned before the
+// channel send on web/callback_controller_handler.go:113.
+func TestSendDirect_EmptyItemList(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("SendDirect with empty ItemList panicked: %v", r)
+		}
+	}()
+
+	SendDirect(&CallBackParam{
+		SceneId:   "test_scene",
+		RequestId: "test-req-id",
+		ItemList:  nil, // the regression: zero candidates after upstream filters
+	})
+}


### PR DESCRIPTION
## Summary

Defense-in-depth fix for a production nil pointer panic in the callback path triggered when upstream filters drop all candidate items.

- **Layer 1** (`callback_hook.go`): early return on `len(items) == 0`
- **Layer 2** (`web/callback_controller_handler.go`): `SendDirect` rejects empty `ItemList`, mirroring `CallBackController.CheckParameter` on the HTTP `/api/callback` path
- **Layer 3** (`service/call_back_service.go`): explicit `if algoData == nil { return }` guard in `Rank()`, so the function defends itself

## Root cause

Commit `6e10261` (perf: skip HTTP self-call in CallBackHookFunc) replaced an HTTP self-call with the new direct-dispatch entry `web.SendDirect`. That HTTP entry was implicitly guarded by `CallBackController.CheckParameter`:

\`\`\`go
if len(r.param.ItemList) == 0 {
    return errors.New(\"recommend item list not empty\")
}
\`\`\`

\`SendDirect\` did not mirror this check. \`CallBackService.Rank\` assumes items are always non-empty (the goroutine fan-out dereferences \`algoData\`, which is only assigned when \`algoGenerator.HasFeatures()\` is true). When filters drop every candidate, \`algoData\` stays nil and the spawned goroutine panics at \`algoData.GetFeatures()\`:

\`\`\`
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x145ed8b]
goroutine 19512 [running]:
github.com/alibaba/pairec/v2/service.(*CallBackService).Rank.func1({...})
    .../service/call_back_service.go:228 +0x22b
\`\`\`

## Test plan

- [x] \`TestCallBackHookFunc_EmptyItems_EarlyReturn\` — hook returns before user access on empty items
- [x] \`TestSendDirect_EmptyItemList\` — SendDirect rejects empty ItemList cleanly
- [x] \`TestCallBackService_Rank_EmptyItems\` — Rank() no panic with nil Items; **without the fix this test reproduces the exact production panic** (\`addr=0x28\`, \`call_back_service.go:228\`)
- [x] Each test individually verified to fail when its corresponding guard is reverted
- [x] \`go test ./service/ ./web/ .\` all green
- [x] Other test failures (\`algorithm/eas\`, \`filter/bloomfilter\`, \`persist/cache\`, etc.) are pre-existing environment-dependency failures on \`origin/master\`, unrelated to this PR

## Review

Code review summary (verdict: ship it) saved to \`doc/code_reviews/2026-06-01-fix-callback-empty-itemlist-panic.md\`. All Important suggestions (I1, I2) and the actionable Minor item (M1) were addressed in the fixup commit \`b42c708\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)