### PR TITLE
fix: guard torchrec mutval response against short output arrays

### DIFF
--- a/algorithm/eas/easyrec_response.go
+++ b/algorithm/eas/easyrec_response.go
@@ -478,8 +478,14 @@ func torchrecMutValResponseFunc(data interface{}) (ret []response.AlgoResponse, 
 		scores := make(map[string]float64)
 		for output, arrayProto := range outputs {
 			if arrayProto.Dtype == easyrec.ArrayDataType_DT_FLOAT {
+				if i >= len(arrayProto.FloatVal) {
+					return nil, fmt.Errorf("torchrec output %s has %d float values for %d items", output, len(arrayProto.FloatVal), len(resp.ItemIds))
+				}
 				scores[output] = float64(arrayProto.FloatVal[i])
 			} else if arrayProto.Dtype == easyrec.ArrayDataType_DT_DOUBLE {
+				if i >= len(arrayProto.DoubleVal) {
+					return nil, fmt.Errorf("torchrec output %s has %d double values for %d items", output, len(arrayProto.DoubleVal), len(resp.ItemIds))
+				}
 				scores[output] = arrayProto.DoubleVal[i]
 			}
 		}
@@ -537,8 +543,14 @@ func torchrecMutValResponseFuncDebug(data interface{}) (ret []response.AlgoRespo
 		scores := make(map[string]float64)
 		for output, arrayProto := range outputs {
 			if arrayProto.Dtype == easyrec.ArrayDataType_DT_FLOAT {
+				if i >= len(arrayProto.FloatVal) {
+					return nil, fmt.Errorf("torchrec output %s has %d float values for %d items", output, len(arrayProto.FloatVal), len(itemIds))
+				}
 				scores[output] = float64(arrayProto.FloatVal[i])
 			} else if arrayProto.Dtype == easyrec.ArrayDataType_DT_DOUBLE {
+				if i >= len(arrayProto.DoubleVal) {
+					return nil, fmt.Errorf("torchrec output %s has %d double values for %d items", output, len(arrayProto.DoubleVal), len(itemIds))
+				}
 				scores[output] = arrayProto.DoubleVal[i]
 			}
 		}

--- a/algorithm/eas/easyrec_response_test.go
+++ b/algorithm/eas/easyrec_response_test.go
@@ -71,3 +71,18 @@ func TestEasyrecMutClassificationResponseFunc(t *testing.T) {
 			float32(0.66))
 	})
 }
+
+func TestTorchrecMutValResponseFuncShortOutput(t *testing.T) {
+	resp := &easyrec.TorchRecPBResponse{}
+	resp.ItemIds = []string{"item_1", "item_2"}
+	resp.MapOutputs = map[string]*easyrec.ArrayProto{
+		"score": {
+			Dtype:    easyrec.ArrayDataType_DT_FLOAT,
+			FloatVal: []float32{0.1},
+		},
+	}
+
+	ret, err := torchrecMutValResponseFunc(resp)
+	assert.Equal(t, ret == nil, true)
+	assert.Equal(t, err != nil, true)
+}


### PR DESCRIPTION
torchrecMutValResponseFunc and its debug variant iterate by len(ItemIds) and index FloatVal[i]/DoubleVal[i] directly, so when an EAS TorchRec output returns a shorter (or empty) value array the index goes out of range and panics the whole process, as reported in #193. This returns an error in that case instead, letting the caller degrade rather than crash. Added a unit test that reproduces the out-of-range access and now passes.