### PR TITLE
fix(easyrec): handle named types in AddUserFeature via reflect fallback

### DIFF
--- a/algorithm/eas/easyrec/easyrec_request_builder.go
+++ b/algorithm/eas/easyrec/easyrec_request_builder.go
@@ -2,13 +2,10 @@ package easyrec
 
 import (
 	"bytes"
-	"fmt"
 	"math"
 	"reflect"
 	"strconv"
 	"strings"
-
-	"github.com/alibaba/pairec/v2/log"
 )
 
 const (
@@ -256,7 +253,6 @@ func (b *EasyrecRequestBuilder) AddUserFeature(k string, v interface{}) {
 				// PBFeature has no unsigned type; a uint value above int64 range
 				// would wrap around to a negative number if cast to int64.
 				// Encode it as a string to preserve the exact value.
-				log.Warning(fmt.Sprintf("AddUserFeature: uint value %d for feature %q exceeds int64 range, encoding as string", uintVal, k))
 				b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_StringFeature{strconv.FormatUint(uintVal, 10)}}
 			}
 		case reflect.Float32:
@@ -267,9 +263,7 @@ func (b *EasyrecRequestBuilder) AddUserFeature(k string, v interface{}) {
 			b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_StringFeature{rv.String()}}
 		default:
 			// Unsupported feature type (struct, map, slice, pointer, bool, typed-nil, ...).
-			// Keep the old no-op behavior instead of writing a meaningless string value,
-			// but log a warning to help diagnose misconfigured features.
-			log.Warning(fmt.Sprintf("AddUserFeature: unsupported feature type %T for feature %q, ignored", v, k))
+			// Keep the old no-op behavior instead of writing a meaningless string value.
 		}
 	}
 }

--- a/algorithm/eas/easyrec/easyrec_request_builder.go
+++ b/algorithm/eas/easyrec/easyrec_request_builder.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 	"strings"
+
+	"github.com/alibaba/pairec/v2/log"
 )
 
 const (
@@ -228,7 +231,14 @@ func (b *EasyrecRequestBuilder) AddUserFeature(k string, v interface{}) {
 		// kind and convert accordingly.
 		rv := reflect.ValueOf(v)
 		switch rv.Kind() {
-		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		case reflect.Int8, reflect.Int16, reflect.Int32:
+			// Always fits in int32, mirrors the concrete int32 case.
+			b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_IntFeature{int32(rv.Int())}}
+		case reflect.Int64:
+			// Mirrors the concrete int64 case: always LongFeature.
+			b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_LongFeature{rv.Int()}}
+		case reflect.Int:
+			// Mirrors the concrete int case: IntFeature if it fits in int32, otherwise LongFeature.
 			intVal := rv.Int()
 			if intVal >= math.MinInt32 && intVal <= math.MaxInt32 {
 				b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_IntFeature{int32(intVal)}}
@@ -237,10 +247,17 @@ func (b *EasyrecRequestBuilder) AddUserFeature(k string, v interface{}) {
 			}
 		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 			uintVal := rv.Uint()
-			if uintVal <= math.MaxInt32 {
+			switch {
+			case uintVal <= math.MaxInt32:
 				b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_IntFeature{int32(uintVal)}}
-			} else {
+			case uintVal <= math.MaxInt64:
 				b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_LongFeature{int64(uintVal)}}
+			default:
+				// PBFeature has no unsigned type; a uint value above int64 range
+				// would wrap around to a negative number if cast to int64.
+				// Encode it as a string to preserve the exact value.
+				log.Warning(fmt.Sprintf("AddUserFeature: uint value %d for feature %q exceeds int64 range, encoding as string", uintVal, k))
+				b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_StringFeature{strconv.FormatUint(uintVal, 10)}}
 			}
 		case reflect.Float32:
 			b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_FloatFeature{float32(rv.Float())}}
@@ -249,8 +266,10 @@ func (b *EasyrecRequestBuilder) AddUserFeature(k string, v interface{}) {
 		case reflect.String:
 			b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_StringFeature{rv.String()}}
 		default:
-			// Last resort: convert to string representation
-			b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_StringFeature{fmt.Sprintf("%v", v)}}
+			// Unsupported feature type (struct, map, slice, pointer, bool, typed-nil, ...).
+			// Keep the old no-op behavior instead of writing a meaningless string value,
+			// but log a warning to help diagnose misconfigured features.
+			log.Warning(fmt.Sprintf("AddUserFeature: unsupported feature type %T for feature %q, ignored", v, k))
 		}
 	}
 }

--- a/algorithm/eas/easyrec/easyrec_request_builder.go
+++ b/algorithm/eas/easyrec/easyrec_request_builder.go
@@ -2,7 +2,9 @@ package easyrec
 
 import (
 	"bytes"
+	"fmt"
 	"math"
+	"reflect"
 	"strings"
 )
 
@@ -216,6 +218,40 @@ func (b *EasyrecRequestBuilder) AddUserFeature(k string, v interface{}) {
 		b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_DoubleLists{DoubleLists: &DoubleLists{Lists: values}}}
 
 	default:
+		// Preserve old behavior: nil features are silently ignored.
+		if v == nil {
+			return
+		}
+		// Handle named types (e.g. time.Month which is based on int) via reflection.
+		// Go's type switch matches concrete types only, so named types like
+		// time.Month won't match "case int:". Use reflect to check the underlying
+		// kind and convert accordingly.
+		rv := reflect.ValueOf(v)
+		switch rv.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			intVal := rv.Int()
+			if intVal >= math.MinInt32 && intVal <= math.MaxInt32 {
+				b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_IntFeature{int32(intVal)}}
+			} else {
+				b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_LongFeature{intVal}}
+			}
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			uintVal := rv.Uint()
+			if uintVal <= math.MaxInt32 {
+				b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_IntFeature{int32(uintVal)}}
+			} else {
+				b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_LongFeature{int64(uintVal)}}
+			}
+		case reflect.Float32:
+			b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_FloatFeature{float32(rv.Float())}}
+		case reflect.Float64:
+			b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_DoubleFeature{rv.Float()}}
+		case reflect.String:
+			b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_StringFeature{rv.String()}}
+		default:
+			// Last resort: convert to string representation
+			b.request.UserFeatures[k] = &PBFeature{Value: &PBFeature_StringFeature{fmt.Sprintf("%v", v)}}
+		}
 	}
 }
 


### PR DESCRIPTION
Go's type switch matches concrete types only, so named types like time.Month (based on int) won't match 'case int:' and are silently dropped. Add a reflect-based fallback in the default branch to check the underlying Kind and convert accordingly.

- Add nil guard to prevent panic on nil interface values
- Use int64/uint64 directly for range checks (avoid int truncation)
- Cover Int/Uint/Float/String kinds with proper PBFeature mapping
- Last resort: convert unknown types to string representation