### PR TITLE
feat: add user_realtime_embedding trigger type for RecallEngine vector recall

### DIFF
--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -474,13 +474,13 @@ type UserEmbeddingO2OTriggerConfig struct {
 	UserFeatureConfs    []FeatureLoadConfig // get user features
 }
 type UserRealtimeEmbeddingTriggerConfig struct {
-	Debug              bool
 	DebugLogDatahub    string
 	EmbeddingNum       int
 	RecallAlgo         string
 	DistinctParamName  string
 	DistinctParamValue string
 	UserFeatureConfs   []FeatureLoadConfig // get user features
+	Debug              bool
 }
 
 type BeTriggerParam struct {

--- a/service/recall/recallenginerecall/trigger_key.go
+++ b/service/recall/recallenginerecall/trigger_key.go
@@ -32,15 +32,15 @@ func NewTriggerKey(recallParam *recconf.RecallEngineParam, client *recallengine.
 	case "u2i_realtime":
 		trigger := NewU2IRealtimeTrigger(&recallParam.UserTriggerDaoConf, &recallParam.UserTriggerRulesConf)
 		return trigger
+	case "user_realtime_embedding":
+		trigger := NewUserRealtimeEmbeddingTrigger(&recallParam.UserRealtimeEmbeddingTrigger)
+		return trigger
 	/*
 		case "user_vector":
 			trigger := NewUserVectorTrigger(&recallParam.UserVectorTrigger)
 			return trigger
 		case "u2i":
 			trigger := NewU2ITrigger(&recallParam.UserCollaborativeDaoConf, &recallParam.UserTriggerRulesConf)
-			return trigger
-		case "user_realtime_embedding":
-			trigger := NewUserRealtimeEmbeddingTrigger(&recallParam.UserRealtimeEmbeddingTrigger)
 			return trigger
 		case "user_realtime_embedding_mind":
 			trigger := NewUserRealtimeEmbeddingMindTrigger(&recallParam.UserRealtimeEmbeddingTrigger)

--- a/service/recall/recallenginerecall/user_realtime_embedding_trigger.go
+++ b/service/recall/recallenginerecall/user_realtime_embedding_trigger.go
@@ -1,0 +1,149 @@
+package recallenginerecall
+
+import (
+	gocontext "context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/alibaba/pairec/v2/algorithm"
+	"github.com/alibaba/pairec/v2/algorithm/eas"
+	"github.com/alibaba/pairec/v2/algorithm/response"
+	"github.com/alibaba/pairec/v2/context"
+	plog "github.com/alibaba/pairec/v2/log"
+	"github.com/alibaba/pairec/v2/module"
+	"github.com/alibaba/pairec/v2/recconf"
+	"github.com/alibaba/pairec/v2/service/feature"
+	"github.com/alibaba/pairec/v2/service/rank"
+)
+
+type UserRealtimeEmbeddingTrigger struct {
+	features       []*feature.Feature
+	recallAlgo     string
+	recallAlgoType string
+	/*
+		embeddingNum                 int
+		datahub                      *datahub.Datahub
+		featureConsistencyJobService *rank.FeatureConsistencyJobService
+	*/
+	useCacheFeatures bool
+	debug            bool
+}
+
+func NewUserRealtimeEmbeddingTrigger(config *recconf.UserRealtimeEmbeddingTriggerConfig) *UserRealtimeEmbeddingTrigger {
+	trigger := &UserRealtimeEmbeddingTrigger{
+		recallAlgo:     config.RecallAlgo,
+		recallAlgoType: eas.Eas_Processor_EASYREC,
+		//embeddingNum:                 config.EmbeddingNum,
+		debug: config.Debug,
+		//featureConsistencyJobService: new(rank.FeatureConsistencyJobService),
+	}
+	var features []*feature.Feature
+	for _, conf := range config.UserFeatureConfs {
+		if conf.FeatureDaoConf.LoadFromCacheFeaturesName != "" {
+			trigger.useCacheFeatures = true
+		}
+		f := feature.LoadWithConfig(conf)
+		features = append(features, f)
+	}
+
+	trigger.features = features
+	/*
+		if trigger.debug {
+			if datahubclient, err := datahub.GetDatahub(config.DebugLogDatahub); err == nil {
+				trigger.datahub = datahubclient
+			} else {
+				plog.Error(fmt.Sprintf("get datahub error:%v", err))
+			}
+		}
+	*/
+
+	return trigger
+}
+func (t *UserRealtimeEmbeddingTrigger) loadUserFeatures(user *module.User, context *context.RecommendContext) {
+	var wg sync.WaitGroup
+	for _, fea := range t.features {
+		wg.Add(1)
+		go func(fea *feature.Feature) {
+			defer wg.Done()
+			fea.LoadFeatures(user, nil, context)
+		}(fea)
+	}
+
+	wg.Wait()
+
+}
+func (t *UserRealtimeEmbeddingTrigger) GetTriggerKey(u *module.User, context *context.RecommendContext) *TriggerResult {
+	//start := time.Now()
+	if t.useCacheFeatures {
+		ctx, cancel := gocontext.WithTimeout(gocontext.Background(), 150*time.Millisecond)
+		defer cancel()
+		select {
+		case <-u.FeatureAsyncLoadCh():
+		case <-ctx.Done():
+			plog.Error(fmt.Sprintf("requestId=%s\tmodule=UserRealtimeEmbeddingTrigger\terror=%v", context.RecommendId, ctx.Err()))
+		}
+	}
+
+	//user := u.Clone()
+	user := u
+	t.loadUserFeatures(user, context)
+	//plog.Info(fmt.Sprintf("requestId=%s\tmodule=UserRealtimeEmbeddingTrigger_loadfeature\tcost=%v", context.RecommendId, utils.CostTime(start)))
+
+	userFeatures := user.MakeUserFeatures2()
+	algoGenerator := rank.CreateAlgoDataGenerator(t.recallAlgoType, nil)
+	algoGenerator.SetItemFeatures(nil)
+	algoGenerator.AddFeatures(nil, nil, userFeatures)
+	//algoData := algoGenerator.GeneratorAlgoDataDebugWithLevel(102, map[string]string{"request_id": context.RecommendId})
+	algoData := algoGenerator.GeneratorAlgoData()
+	//easyrecRequest := algoData.GetFeatures().(*easyrec.PBRequest)
+	//easyrecRequest.FaissNeighNum = int32(t.embeddingNum)
+	algoRet, err := algorithm.Run(t.recallAlgo, algoData.GetFeatures())
+
+	//var triggerItem string
+	//var triggerItems []string
+	var userEmbedding string
+
+	if err != nil {
+		plog.Error(fmt.Sprintf("requestId=%s\tmodule=UserRealtimeEmbeddingTrigger\terr=%v", context.RecommendId, err))
+	} else {
+		// eas model invoke success
+		if result, ok := algoRet.([]response.AlgoResponse); ok && len(result) > 0 {
+			if embeddingReponse, ok := result[0].(*eas.TorchrecEmbeddingResponse); ok {
+				embeddings := embeddingReponse.GetEmbedding()
+				embeddingList := make([]string, 0, len(embeddings))
+				for _, embedding := range embeddings {
+					embeddingList = append(embeddingList, strconv.FormatFloat(float64(embedding), 'f', -1, 32))
+				}
+
+				userEmbedding = strings.Join(embeddingList, ",")
+			} else {
+				plog.Error(fmt.Sprintf("requestId=%s\tmodule=UserRealtimeEmbeddingTrigger\terror=unexpected response type, expected *eas.TorchrecEmbeddingResponse, got %T", context.RecommendId, result[0]))
+			}
+			/*
+				if response, ok := result[0].(*eas.EasyrecUserRealtimeEmbeddingResponse); ok {
+					userEmbedding = response.GetUserEmbedding()
+					for _, info := range response.GetEmbeddingList() {
+						triggerItems = append(triggerItems, fmt.Sprintf("%s:%f", info.ItemId, info.Score))
+					}
+
+					triggerItem = strings.Join(triggerItems, ",")
+				}
+			*/
+		}
+
+	}
+	if context.Debug {
+		plog.Info(fmt.Sprintf("requestId=%s\tmodule=UserRealtimeEmbeddingTrigger\tuserEmbedding=%s", context.RecommendId, userEmbedding))
+	}
+
+	//go t.featureConsistencyJobService.LogRecallResult(user, nil, context, "dssm", userEmbedding, triggerItem, t.recallAlgo, t.recallAlgoType, "", "", "")
+
+	triggerResult := &TriggerResult{
+		TriggerItem: userEmbedding,
+	}
+	//plog.Info(fmt.Sprintf("requestId=%s\tmodule=UserRealtimeEmbeddingTrigger\tcost=%v", context.RecommendId, utils.CostTime(start)))
+	return triggerResult
+}

--- a/service/recall/recallenginerecall/user_realtime_embedding_trigger.go
+++ b/service/recall/recallenginerecall/user_realtime_embedding_trigger.go
@@ -87,8 +87,7 @@ func (t *UserRealtimeEmbeddingTrigger) GetTriggerKey(u *module.User, context *co
 		}
 	}
 
-	//user := u.Clone()
-	user := u
+	user := u.Clone()
 	t.loadUserFeatures(user, context)
 	//plog.Info(fmt.Sprintf("requestId=%s\tmodule=UserRealtimeEmbeddingTrigger_loadfeature\tcost=%v", context.RecommendId, utils.CostTime(start)))
 


### PR DESCRIPTION
## Summary

Add a new trigger type `user_realtime_embedding` for RecallEngine recall, which fetches user vectors from EAS Processor and uses them as triggers for vector recall.

## Changes

- **recconf/recconf.go**: Reorder fields in `UserRealtimeEmbeddingTriggerConfig`
- **service/recall/recallenginerecall/trigger_key.go**: Register `user_realtime_embedding` trigger type
- **service/recall/recallenginerecall/user_realtime_embedding_trigger.go**: New file implementing `UserRealtimeEmbeddingTrigger`

## How it works

1. Load user features (supports async cache features)
2. Build EasyRec PB request with user features
3. Call EAS model via `algorithm.Run` to get user embedding
4. Convert embedding (`[]float32`) to comma-separated string as trigger
5. Pass trigger to RecallEngine for vector recall

Aone: #83464347