### PR TITLE
feat: support RecallOptions with TriggerLimit for X2I recall engine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	fortio.org/assert v1.2.1
 	github.com/alibabacloud-go/opensearch-util v1.0.1
 	github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260430015117-503e97905dba
-	github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260323112208-51b86e8512e0
+	github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260618074343-c5300c5ac3e4
 	github.com/aliyun/credentials-go v1.4.8
 	github.com/apache/calcite-avatica-go/v5 v5.0.0
 	github.com/bruceding/go-antlr-valuate v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260430015117-503e
 github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260430015117-503e97905dba/go.mod h1:1nP9jGmFj7jSmeSKCTdMkxdpByhPGnPQE0Im1Eyyd6Q=
 github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260323112208-51b86e8512e0 h1:/vetP0u6yEA6yT+16nkB5ADSHFH6c3nHzf9tsIXXWt4=
 github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260323112208-51b86e8512e0/go.mod h1:TjHkSEFlBAPhzp5sT5rheXSorgIdKxVh/2MVG2qHXmA=
+github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260618074343-c5300c5ac3e4 h1:RBagQYejYQBtNp+qzhEaC3EOCUMhNaqyJWV17wxmR4w=
+github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260618074343-c5300c5ac3e4/go.mod h1:TjHkSEFlBAPhzp5sT5rheXSorgIdKxVh/2MVG2qHXmA=
 github.com/aliyun/aliyun-tablestore-go-sdk v1.7.7 h1:+d/mcgaxx1jaWtFN2WrBHy4XeM9IK5gmZvbbpVkhqHE=
 github.com/aliyun/aliyun-tablestore-go-sdk v1.7.7/go.mod h1:mZCxM44kLKLY5ci+0j6bJb0DG8PNQ5Mn40Y0bbYOhpE=
 github.com/aliyun/credentials-go v1.1.2/go.mod h1:ozcZaMR5kLM7pwtCMEpVmQ242suV6qTJya2bDq4X1Tw=

--- a/module/trigger.go
+++ b/module/trigger.go
@@ -104,6 +104,47 @@ func (t *Trigger) GetValue(features map[string]interface{}) string {
 	return strings.Join(values, "_")
 }
 
+// GetTriggerValues returns per-dimension trigger values as a string slice.
+// Each element is one trigger item's value (may contain TIRRGER_SPLIT for array features).
+func (t *Trigger) GetTriggerValues(features map[string]interface{}) []string {
+	values := make([]string, 0, len(t.triggers))
+	for _, trigger := range t.triggers {
+		if val, ok := features[trigger.Key]; ok {
+			values = append(values, trigger.GetValue(val))
+		} else {
+			values = append(values, trigger.DefaultValue)
+		}
+	}
+	return values
+}
+
+// ParseTriggerValues expands trigger values into cartesian product combinations,
+// joined with comma. Unlike ParseTriggerId which splits by "_", this function
+// takes pre-split per-dimension values to avoid ambiguity when values contain "_".
+func ParseTriggerValues(triggerValues []string) string {
+	combinations := []string{""}
+	for _, val := range triggerValues {
+		var items []string
+		if strings.Contains(val, TIRRGER_SPLIT) {
+			items = strings.Split(val, TIRRGER_SPLIT)
+		} else {
+			items = []string{val}
+		}
+		var next []string
+		for _, combo := range combinations {
+			for _, item := range items {
+				if combo == "" {
+					next = append(next, item)
+				} else {
+					next = append(next, combo+"_"+item)
+				}
+			}
+		}
+		combinations = next
+	}
+	return strings.Join(combinations, ",")
+}
+
 func ParseTriggerId(triggerId string) []any {
 	if !strings.ContainsAny(triggerId, TIRRGER_SPLIT) {
 		return []any{triggerId}

--- a/module/trigger.go
+++ b/module/trigger.go
@@ -123,7 +123,7 @@ func (t *Trigger) GetTriggerValues(features map[string]interface{}) []string {
 // takes pre-split per-dimension values to avoid ambiguity when values contain "_".
 func ParseTriggerValues(triggerValues []string) string {
 	combinations := []string{""}
-	for _, val := range triggerValues {
+	for i, val := range triggerValues {
 		var items []string
 		if strings.Contains(val, TIRRGER_SPLIT) {
 			items = strings.Split(val, TIRRGER_SPLIT)
@@ -133,7 +133,7 @@ func ParseTriggerValues(triggerValues []string) string {
 		var next []string
 		for _, combo := range combinations {
 			for _, item := range items {
-				if combo == "" {
+				if i == 0 {
 					next = append(next, item)
 				} else {
 					next = append(next, combo+"_"+item)

--- a/module/trigger_test.go
+++ b/module/trigger_test.go
@@ -120,6 +120,105 @@ func TestMultiTrigger(t *testing.T) {
 	}
 }
 
+func TestParseTrigger(t *testing.T) {
+
+	t.Run("parse single multi trigger", func(t *testing.T) {
+		config := []recconf.TriggerConfig{
+			{
+				TriggerKey: "tags",
+			},
+		}
+
+		testcases := []struct {
+			features  map[string]interface{}
+			expectVal string
+		}{
+			{
+				features: map[string]interface{}{"sex": "Male",
+					"tags": []string{"tag1", "tag2", "tag3"},
+					"age":  23,
+				},
+				expectVal: strings.Join([]string{"tag1", "tag2", "tag3"}, TIRRGER_SPLIT),
+			},
+			{
+				features: map[string]interface{}{"sex": "Male",
+					"tags": []any{"tag1", "tag2", "tag3"},
+					"age":  23,
+				},
+				expectVal: strings.Join([]string{"tag1", "tag2", "tag3"}, TIRRGER_SPLIT),
+			},
+		}
+
+		trigger := NewTrigger(config)
+
+		for _, testcase := range testcases {
+			fmt.Println(trigger.GetValue(testcase.features))
+			assert.Equal(t, trigger.GetValue(testcase.features), testcase.expectVal)
+			triggers := ParseTriggerId(trigger.GetValue(testcase.features))
+			var strs []string
+			for _, trigger := range triggers {
+				strs = append(strs, trigger.(string))
+			}
+			assert.Equal(t, strings.Join(strs, TIRRGER_SPLIT), testcase.expectVal)
+		}
+
+	})
+	t.Run("parse multi triggers", func(t *testing.T) {
+		config := []recconf.TriggerConfig{
+			{
+				TriggerKey: "tags",
+			},
+			{
+				TriggerKey: "age",
+			},
+		}
+
+		testcases := []struct {
+			features  map[string]interface{}
+			expectVal []any
+		}{
+			{
+				features: map[string]interface{}{"sex": "Male",
+					"tags": []string{"tag1", "tag2", "tag3"},
+					"age":  23,
+				},
+				expectVal: []any{"tag1_23", "tag2_23", "tag3_23"},
+			},
+			{
+				features: map[string]interface{}{"sex": "Male",
+					"tags": []any{"tag1", "tag2", "tag3"},
+					"age":  34,
+				},
+				expectVal: []any{"tag1_34", "tag2_34", "tag3_34"},
+			},
+			{
+				features: map[string]interface{}{"sex": "Male",
+					"tags": "tag1",
+					"age":  34,
+				},
+				expectVal: []any{"tag1_34"},
+			},
+			{
+				features: map[string]interface{}{"sex": "Male",
+					"tags": []any{"tag1", "tag2"},
+					"age":  []any{34, 23},
+				},
+				expectVal: []any{"tag1_34", "tag1_23", "tag2_34", "tag2_23"},
+			},
+		}
+
+		trigger := NewTrigger(config)
+
+		for _, testcase := range testcases {
+			fmt.Println(trigger.GetValue(testcase.features))
+			triggers := ParseTriggerId(trigger.GetValue(testcase.features))
+			t.Log(triggers...)
+			assert.Equal(t, triggers, testcase.expectVal)
+		}
+
+	})
+}
+
 func TestParseTriggerValues(t *testing.T) {
 	t.Run("single value single dimension", func(t *testing.T) {
 		config := []recconf.TriggerConfig{

--- a/module/trigger_test.go
+++ b/module/trigger_test.go
@@ -205,4 +205,21 @@ func TestParseTriggerValues(t *testing.T) {
 		result := ParseTriggerValues(trigger.GetTriggerValues(features))
 		assert.Equal(t, result, "trigger_a_unknown,trigger_b_unknown")
 	})
+
+	t.Run("empty string value preserves dimension", func(t *testing.T) {
+		// When first dimension is empty string, second dimension should still be "_Android"
+		result := ParseTriggerValues([]string{"", "Android"})
+		assert.Equal(t, result, "_Android")
+	})
+
+	t.Run("empty array produces empty string", func(t *testing.T) {
+		config := []recconf.TriggerConfig{
+			{TriggerKey: "tags"},
+			{TriggerKey: "os"},
+		}
+		trigger := NewTrigger(config)
+		features := map[string]interface{}{"tags": []string{}, "os": "Android"}
+		result := ParseTriggerValues(trigger.GetTriggerValues(features))
+		assert.Equal(t, result, "_Android")
+	})
 }

--- a/module/trigger_test.go
+++ b/module/trigger_test.go
@@ -120,101 +120,89 @@ func TestMultiTrigger(t *testing.T) {
 	}
 }
 
-func TestParseTrigger(t *testing.T) {
-
-	t.Run("parse sigle multi trigger", func(t *testing.T) {
+func TestParseTriggerValues(t *testing.T) {
+	t.Run("single value single dimension", func(t *testing.T) {
 		config := []recconf.TriggerConfig{
-			{
-				TriggerKey: "tags",
-			},
+			{TriggerKey: "category"},
 		}
-
-		testcases := []struct {
-			features  map[string]interface{}
-			expectVal string
-		}{
-			{
-				features: map[string]interface{}{"sex": "Male",
-					"tags": []string{"tag1", "tag2", "tag3"},
-					"age":  23,
-				},
-				expectVal: strings.Join([]string{"tag1", "tag2", "tag3"}, TIRRGER_SPLIT),
-			},
-			{
-				features: map[string]interface{}{"sex": "Male",
-					"tags": []any{"tag1", "tag2", "tag3"},
-					"age":  23,
-				},
-				expectVal: strings.Join([]string{"tag1", "tag2", "tag3"}, TIRRGER_SPLIT),
-			},
-		}
-
 		trigger := NewTrigger(config)
-
-		for _, testcase := range testcases {
-			fmt.Println(trigger.GetValue(testcase.features))
-			assert.Equal(t, trigger.GetValue(testcase.features), testcase.expectVal)
-			triggers := ParseTriggerId(trigger.GetValue(testcase.features))
-			var strs []string
-			for _, trigger := range triggers {
-				strs = append(strs, trigger.(string))
-			}
-			assert.Equal(t, strings.Join(strs, TIRRGER_SPLIT), testcase.expectVal)
-		}
-
+		features := map[string]interface{}{"category": "sports"}
+		result := ParseTriggerValues(trigger.GetTriggerValues(features))
+		assert.Equal(t, result, "sports")
 	})
-	t.Run("parse  multi triggers", func(t *testing.T) {
+
+	t.Run("array value single dimension", func(t *testing.T) {
 		config := []recconf.TriggerConfig{
-			{
-				TriggerKey: "tags",
-			},
-			{
-				TriggerKey: "age",
-			},
+			{TriggerKey: "triggers"},
 		}
-
-		testcases := []struct {
-			features  map[string]interface{}
-			expectVal []any
-		}{
-			{
-				features: map[string]interface{}{"sex": "Male",
-					"tags": []string{"tag1", "tag2", "tag3"},
-					"age":  23,
-				},
-				expectVal: []any{"tag1_23", "tag2_23", "tag3_23"},
-			},
-			{
-				features: map[string]interface{}{"sex": "Male",
-					"tags": []any{"tag1", "tag2", "tag3"},
-					"age":  34,
-				},
-				expectVal: []any{"tag1_34", "tag2_34", "tag3_34"},
-			},
-			{
-				features: map[string]interface{}{"sex": "Male",
-					"tags": "tag1",
-					"age":  34,
-				},
-				expectVal: []any{"tag1_34"},
-			},
-			{
-				features: map[string]interface{}{"sex": "Male",
-					"tags": []any{"tag1", "tag2"},
-					"age":  []any{34, 23},
-				},
-				expectVal: []any{"tag1_34", "tag1_23", "tag2_34", "tag2_23"},
-			},
-		}
-
 		trigger := NewTrigger(config)
+		features := map[string]interface{}{"triggers": []string{"trigger_a", "trigger_b"}}
+		result := ParseTriggerValues(trigger.GetTriggerValues(features))
+		assert.Equal(t, result, "trigger_a,trigger_b")
+	})
 
-		for _, testcase := range testcases {
-			fmt.Println(trigger.GetValue(testcase.features))
-			triggers := ParseTriggerId(trigger.GetValue(testcase.features))
-			t.Log(triggers...)
-			assert.Equal(t, triggers, testcase.expectVal)
+	t.Run("array value with underscore in values", func(t *testing.T) {
+		config := []recconf.TriggerConfig{
+			{TriggerKey: "tags"},
 		}
+		trigger := NewTrigger(config)
+		features := map[string]interface{}{"tags": []any{"item_tag_1", "item_tag_2", "item_tag_3"}}
+		result := ParseTriggerValues(trigger.GetTriggerValues(features))
+		assert.Equal(t, result, "item_tag_1,item_tag_2,item_tag_3")
+	})
 
+	t.Run("multi dimension single values", func(t *testing.T) {
+		config := []recconf.TriggerConfig{
+			{TriggerKey: "sex"},
+			{TriggerKey: "os"},
+		}
+		trigger := NewTrigger(config)
+		features := map[string]interface{}{"sex": "Male", "os": "IOS"}
+		result := ParseTriggerValues(trigger.GetTriggerValues(features))
+		assert.Equal(t, result, "Male_IOS")
+	})
+
+	t.Run("multi dimension with array", func(t *testing.T) {
+		config := []recconf.TriggerConfig{
+			{TriggerKey: "tags"},
+			{TriggerKey: "os"},
+		}
+		trigger := NewTrigger(config)
+		features := map[string]interface{}{"tags": []string{"tag_a", "tag_b"}, "os": "Android"}
+		result := ParseTriggerValues(trigger.GetTriggerValues(features))
+		assert.Equal(t, result, "tag_a_Android,tag_b_Android")
+	})
+
+	t.Run("multi dimension both arrays", func(t *testing.T) {
+		config := []recconf.TriggerConfig{
+			{TriggerKey: "tags"},
+			{TriggerKey: "levels"},
+		}
+		trigger := NewTrigger(config)
+		features := map[string]interface{}{"tags": []string{"tag_a", "tag_b"}, "levels": []any{"L1", "L2"}}
+		result := ParseTriggerValues(trigger.GetTriggerValues(features))
+		assert.Equal(t, result, "tag_a_L1,tag_a_L2,tag_b_L1,tag_b_L2")
+	})
+
+	t.Run("with boundaries", func(t *testing.T) {
+		config := []recconf.TriggerConfig{
+			{TriggerKey: "sex"},
+			{TriggerKey: "age", Boundaries: []int{20, 30, 40}},
+		}
+		trigger := NewTrigger(config)
+		features := map[string]interface{}{"sex": "Male", "age": 25}
+		result := ParseTriggerValues(trigger.GetTriggerValues(features))
+		assert.Equal(t, result, "Male_20-30")
+	})
+
+	t.Run("missing feature uses default", func(t *testing.T) {
+		config := []recconf.TriggerConfig{
+			{TriggerKey: "tags"},
+			{TriggerKey: "city", DefaultValue: "unknown"},
+		}
+		trigger := NewTrigger(config)
+		features := map[string]interface{}{"tags": []string{"trigger_a", "trigger_b"}}
+		result := ParseTriggerValues(trigger.GetTriggerValues(features))
+		assert.Equal(t, result, "trigger_a_unknown,trigger_b_unknown")
 	})
 }

--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -426,6 +426,7 @@ type RecallEngineParam struct {
 	RecallTableName string
 	DiversityParam  string
 	CustomParams    map[string]interface{}
+	TriggerLimit    int
 }
 type RecallNameMappingConfig struct {
 	Format string

--- a/service/recall/recallenginerecall/service_recall.go
+++ b/service/recall/recallenginerecall/service_recall.go
@@ -121,6 +121,7 @@ func NewRecallEngineServiceRecall(client *recallengine.RecallEngineClient, conf 
 				recallTableName: param.RecallTableName,
 				diversityParam:  param.DiversityParam,
 				customParams:    param.CustomParams,
+				triggerLimit:    param.TriggerLimit,
 				triggerKey:      NewTriggerKey(&param, client),
 				client:          client,
 				cloneInstances:  make(map[string]*RecallEngineX2IRecall),

--- a/service/recall/recallenginerecall/trigger_key.go
+++ b/service/recall/recallenginerecall/trigger_key.go
@@ -69,8 +69,9 @@ func NewUserTrigger(userTriggers []recconf.TriggerConfig) *UserTrigger {
 	return &t
 }
 func (t *UserTrigger) GetTriggerKey(user *module.User, context *context.RecommendContext) *TriggerResult {
+	triggerValues := t.trigger.GetTriggerValues(user.MakeUserFeatures2())
 	return &TriggerResult{
-		TriggerItem: t.trigger.GetValue(user.MakeUserFeatures2()),
+		TriggerItem: module.ParseTriggerValues(triggerValues),
 	}
 }
 

--- a/service/recall/recallenginerecall/x2i_recall.go
+++ b/service/recall/recallenginerecall/x2i_recall.go
@@ -162,6 +162,7 @@ func (r *RecallEngineX2IRecall) CloneWithConfig(params map[string]interface{}) R
 		customParams:    recallParams.CustomParams,
 		triggerLimit:    recallParams.TriggerLimit,
 		triggerKey:      NewTriggerKey(&recallParams, r.client),
+		cloneInstances:  make(map[string]*RecallEngineX2IRecall),
 	}
 
 	r.cloneInstances[md5] = recall

--- a/service/recall/recallenginerecall/x2i_recall.go
+++ b/service/recall/recallenginerecall/x2i_recall.go
@@ -24,6 +24,7 @@ type RecallEngineX2IRecall struct {
 	recallTableName string
 	diversityParam  string
 	customParams    map[string]interface{}
+	triggerLimit    int
 	triggerKey      TriggerKey
 	client          *recallengine.RecallEngineClient
 	mu              sync.RWMutex
@@ -44,6 +45,7 @@ func NewRecallEngineX2IRecall(client *recallengine.RecallEngineClient, conf recc
 		recallTableName: conf.RecallEngineParams[0].RecallTableName,
 		diversityParam:  conf.RecallEngineParams[0].DiversityParam,
 		customParams:    conf.RecallEngineParams[0].CustomParams,
+		triggerLimit:    conf.RecallEngineParams[0].TriggerLimit,
 		triggerKey:      NewTriggerKey(&conf.RecallEngineParams[0], nil),
 		client:          client,
 		cloneInstances:  make(map[string]*RecallEngineX2IRecall),
@@ -67,6 +69,9 @@ func (r *RecallEngineX2IRecall) BuildQueryParams(user *module.User, context *con
 
 	ret.Trigger = triggerResult.TriggerItem
 	ret.Count = r.returnCount
+	if r.triggerLimit > 0 {
+		ret.Options = &re.RecallOptions{TriggerLimit: r.triggerLimit}
+	}
 	return
 
 	/*
@@ -155,6 +160,7 @@ func (r *RecallEngineX2IRecall) CloneWithConfig(params map[string]interface{}) R
 		recallTableName: recallParams.RecallTableName,
 		diversityParam:  recallParams.DiversityParam,
 		customParams:    recallParams.CustomParams,
+		triggerLimit:    recallParams.TriggerLimit,
 		triggerKey:      NewTriggerKey(&recallParams, r.client),
 	}
 


### PR DESCRIPTION
## Summary

Add support for the new `RecallOptions` parameter (with `TriggerLimit`) in the X2I recall engine type.

## Changes

- Upgrade `aliyun-pairec-config-go-sdk` to include `RecallOptions` struct
- Add `TriggerLimit int` field to `RecallEngineParam` config
- Pass `RecallOptions` in X2I recall's `BuildQueryParams` when `TriggerLimit > 0`
- No impact on existing configurations (backward compatible)

## Key Files

- `recconf/recconf.go` - Config struct update
- `service/recall/recallenginerecall/x2i_recall.go` - X2I recall implementation
- `service/recall/recallenginerecall/service_recall.go` - Instance creation