### PR TITLE
fix: prevent SnakeFilter SKIP_ON_DUPLICATE from dropping candidates

### DIFF
--- a/filter/snake_filter.go
+++ b/filter/snake_filter.go
@@ -212,18 +212,31 @@ func (f *SnakeFilter) doFilter(filterData *FilterData) error {
 	size := 0
 	for size < f.retainNum {
 		iterSize := 0
+		progressed := false
 		for i, config := range f.configs {
 			iter := snakeItemIterators[i]
+			before := iter.index
 			items := iter.Next(config.Weight)
+			if iter.index > before {
+				progressed = true
+			}
 			if len(items) > 0 {
 				iterSize += len(items)
 				newItems = append(newItems, items...)
 			}
 		}
-		if iterSize == 0 {
+		size += iterSize
+
+		// Terminate only when a full round advances no iterator at all. Under
+		// SKIP_ON_DUPLICATE a round can yield nothing (iterSize == 0) because every
+		// iterator landed on an already-taken duplicate; that must not stop the loop
+		// while fresh items remain, or the remaining candidates are silently
+		// dropped. Keying on index progress (rather than iterSize) also guarantees
+		// termination when a recall is misconfigured with weight <= 0, whose Next
+		// never advances.
+		if !progressed {
 			break
 		}
-		size += iterSize
 	}
 
 	if len(newItems) > f.retainNum {

--- a/filter/snake_filter_test.go
+++ b/filter/snake_filter_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"fortio.org/assert"
 	"github.com/alibaba/pairec/v2/context"
@@ -525,4 +526,135 @@ func TestSnakeFilter(t *testing.T) {
 			t.Log(item)
 		}
 	})
+}
+
+// TestSnakeFilterSkipNoEarlyBreak is a regression test for a bug where the
+// SKIP_ON_DUPLICATE main loop terminates early (iterSize==0 -> break) and drops
+// still-available items.
+//
+// Setup: X and Y are multi-recall items ranked in OPPOSITE order in the two
+// iterators (X high in A / low in B, Y low in A / high in B). With weight=1 each
+// Next(1) advances only one slot; on round 2 both iterators point at an
+// already-taken duplicate at the same time, so iterSize==0 triggers break and the
+// still-fresh items a1 and b1 are lost.
+//
+// RetainNum is 100 and there are only 4 unique items, so a correct implementation
+// must keep all 4. This test FAILS before the fix (returns 2) and passes after.
+func TestSnakeFilterSkipNoEarlyBreak(t *testing.T) {
+	X := &module.Item{
+		Id: "X", Score: 100, RetrieveId: "recall_A", Properties: map[string]interface{}{},
+		RecallScores: map[string]float64{"recall_A": 100, "recall_B": 1},
+	}
+	Y := &module.Item{
+		Id: "Y", Score: 100, RetrieveId: "recall_B", Properties: map[string]interface{}{},
+		RecallScores: map[string]float64{"recall_A": 1, "recall_B": 100},
+	}
+	a1 := &module.Item{Id: "a1", Score: 0.5, RetrieveId: "recall_A", Properties: map[string]interface{}{}}
+	b1 := &module.Item{Id: "b1", Score: 0.5, RetrieveId: "recall_B", Properties: map[string]interface{}{}}
+	items := []*module.Item{X, Y, a1, b1}
+
+	filter := NewSnakeFilter(recconf.FilterConfig{
+		Name:      "snake_filter",
+		RetainNum: 100,
+		SnakeType: "SKIP_ON_DUPLICATE",
+		AdjustCountConfs: []recconf.AdjustCountConfig{
+			{RecallName: "recall_A", Weight: 1},
+			{RecallName: "recall_B", Weight: 1},
+		},
+	})
+
+	filterData := FilterData{Context: &context.RecommendContext{}, Data: items}
+	filter.doFilter(&filterData)
+	newItems := filterData.Data.([]*module.Item)
+
+	got := make(map[string]bool, len(newItems))
+	for _, item := range newItems {
+		got[string(item.Id)] = true
+	}
+	assert.Equal(t, 4, len(newItems))
+	for _, id := range []string{"X", "Y", "a1", "b1"} {
+		assert.Equal(t, true, got[id])
+	}
+}
+
+// TestSnakeFilterSkipStableCount is a regression test that the output count of
+// SKIP_ON_DUPLICATE does not collapse in the presence of cross-recall duplicates.
+//
+// This mirrors the production shape (post-UniqueFilter): a dominant recall
+// (recall_A) owns 100 unique items, 10 of which are multi-recall (also belong to
+// recall_B). All scores are 0 (e.g. a context list carrying no score), so the
+// per-iterator sort is unstable and the 10 shared items land at arbitrary
+// positions. With weight=1 the main loop advances one slot per recall per round;
+// once recall_B is exhausted, the first round on which recall_A happens to land
+// on a shared item that recall_B already took makes iterSize==0 and the loop
+// breaks -- dropping all of recall_A's remaining unique items.
+//
+// 100 unique items exist and RetainNum is 540, so a correct implementation keeps
+// all 100. Before the fix the count collapses (far below 100); after the fix it
+// is stable at 100.
+func TestSnakeFilterSkipStableCount(t *testing.T) {
+	var items []*module.Item
+	for i := 0; i < 100; i++ {
+		item := &module.Item{
+			Id: module.ItemId(fmt.Sprintf("item_%d", i)), Score: 0,
+			RetrieveId: "recall_A", Properties: map[string]interface{}{},
+		}
+		if i%10 == 0 { // item_0, item_10, ..., item_90 are also recalled by recall_B
+			item.RecallScores = map[string]float64{"recall_A": 0, "recall_B": 0}
+		}
+		items = append(items, item)
+	}
+
+	filter := NewSnakeFilter(recconf.FilterConfig{
+		Name:      "snake_filter",
+		RetainNum: 540,
+		SnakeType: "SKIP_ON_DUPLICATE",
+		AdjustCountConfs: []recconf.AdjustCountConfig{
+			{RecallName: "recall_A", Weight: 1},
+			{RecallName: "recall_B", Weight: 1},
+		},
+	})
+
+	filterData := FilterData{Context: &context.RecommendContext{}, Data: items}
+	filter.doFilter(&filterData)
+	newItems := filterData.Data.([]*module.Item)
+
+	// 100 unique items exist; none should be dropped by dedup early-break.
+	assert.Equal(t, 100, len(newItems))
+}
+
+// TestSnakeFilterZeroWeightTerminates guards the loop against a recall configured
+// with weight <= 0. Next(0) never advances the iterator index, so a termination
+// condition keyed purely on "all iterators exhausted" would spin forever. The
+// loop must instead stop when a full round makes no progress. This test fails by
+// timing out if that guarantee regresses.
+func TestSnakeFilterZeroWeightTerminates(t *testing.T) {
+	items := []*module.Item{
+		{Id: "a1", Score: 1, RetrieveId: "recall_A", Properties: map[string]interface{}{}},
+		{Id: "b1", Score: 1, RetrieveId: "recall_B", Properties: map[string]interface{}{}},
+	}
+	filter := NewSnakeFilter(recconf.FilterConfig{
+		Name:      "snake_filter",
+		RetainNum: 100,
+		SnakeType: "SKIP_ON_DUPLICATE",
+		AdjustCountConfs: []recconf.AdjustCountConfig{
+			{RecallName: "recall_A", Weight: 1},
+			{RecallName: "recall_B", Weight: 0}, // misconfigured: weight omitted -> 0
+		},
+	})
+
+	done := make(chan int, 1)
+	go func() {
+		filterData := FilterData{Context: &context.RecommendContext{}, Data: items}
+		filter.doFilter(&filterData)
+		done <- len(filterData.Data.([]*module.Item))
+	}()
+
+	select {
+	case n := <-done:
+		// recall_A (weight 1) still yields its item; recall_B (weight 0) yields none.
+		assert.Equal(t, 1, n)
+	case <-time.After(3 * time.Second):
+		t.Fatal("doFilter did not terminate: infinite loop with weight <= 0")
+	}
 }


### PR DESCRIPTION
## Problem

Under `SnakeType=SKIP_ON_DUPLICATE`, `SnakeFilter` can non-deterministically collapse the candidate count. Observed in production: the **same user + same experiment (same `exp_id`) + same recall inputs** returned **5 items on one request and 500 on the next**.

## Root cause

In `filter/snake_filter.go` `doFilter`, the main loop broke on the first round that produced nothing:

```go
if iterSize == 0 { break }
```

In SKIP mode, `Next()` consumes a quota slot and returns empty when it lands on an already-taken duplicate (it does **not** advance to the next fresh item). So a round can yield nothing while iterators still hold fresh items. The premature `break` then silently dropped all remaining candidates.

This only triggers when there are cross-recall duplicate items (e.g. a context list overlapping cold-start recalls) — combined with parallel recall ordering and unstable sort of equal-score items, the break point varies per request, hence the flapping between 5 and 500. A dominant recall owning most of the candidates does **not** protect against it: once a round lands on a duplicate while the small recalls are exhausted, the dominant recall's remaining fresh items are dropped too.

## Fix

Terminate only when a **full round advances no iterator at all** (keyed on `index` progress rather than `iterSize`):

- Keeps the fresh items that were being dropped.
- `Next()` is unchanged, so REFILL and SKIP quota/ordering semantics are preserved (in REFILL, `iterSize == 0` only ever coincided with full exhaustion, so behavior is identical).
- Also guarantees termination when a recall is misconfigured with `weight <= 0`. `Next(0)` never advances `index`, so a condition keyed purely on "all iterators exhausted" would spin forever — `AdjustCountConfig.Weight` is an unvalidated `int` that JSON defaults to 0, so this is reachable.

## Tests

- `TestSnakeFilterSkipNoEarlyBreak` — minimal deterministic early-break (was 2, now 4).
- `TestSnakeFilterSkipStableCount` — production shape: dominant recall of 100 unique items, 10 multi-recall (was 19, now 100).
- `TestSnakeFilterZeroWeightTerminates` — timeout-guarded regression for the `weight <= 0` hang.

All existing `SnakeFilter` tests and the full `filter` package pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)