### PR TITLE
feat(recall): support per-way timeout for recall engine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	fortio.org/assert v1.2.1
 	github.com/alibabacloud-go/opensearch-util v1.0.1
 	github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260615014040-028ca7fc0c42
-	github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260618074343-c5300c5ac3e4
+	github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260714015931-6e1064f3fe1a
 	github.com/aliyun/credentials-go v1.4.8
 	github.com/apache/calcite-avatica-go/v5 v5.0.0
 	github.com/bruceding/go-antlr-valuate v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260323112208-51b86e8
 github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260323112208-51b86e8512e0/go.mod h1:TjHkSEFlBAPhzp5sT5rheXSorgIdKxVh/2MVG2qHXmA=
 github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260618074343-c5300c5ac3e4 h1:RBagQYejYQBtNp+qzhEaC3EOCUMhNaqyJWV17wxmR4w=
 github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260618074343-c5300c5ac3e4/go.mod h1:TjHkSEFlBAPhzp5sT5rheXSorgIdKxVh/2MVG2qHXmA=
+github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260714015931-6e1064f3fe1a h1:FuXOWqmoFfpGl5TM/H0bgDDNVTMNbfG5pIEp3eI17AA=
+github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260714015931-6e1064f3fe1a/go.mod h1:TjHkSEFlBAPhzp5sT5rheXSorgIdKxVh/2MVG2qHXmA=
 github.com/aliyun/aliyun-tablestore-go-sdk v1.7.7 h1:+d/mcgaxx1jaWtFN2WrBHy4XeM9IK5gmZvbbpVkhqHE=
 github.com/aliyun/aliyun-tablestore-go-sdk v1.7.7/go.mod h1:mZCxM44kLKLY5ci+0j6bJb0DG8PNQ5Mn40Y0bbYOhpE=
 github.com/aliyun/credentials-go v1.1.2/go.mod h1:ozcZaMR5kLM7pwtCMEpVmQ242suV6qTJya2bDq4X1Tw=

--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -444,6 +444,7 @@ type RecallEngineParam struct {
 	DiversityParam  string
 	CustomParams    map[string]interface{}
 	TriggerLimit    int
+	Timeout         int // per-way recall timeout in milliseconds, 0 means no per-way timeout
 }
 type RecallNameMappingConfig struct {
 	Format string

--- a/service/recall/recallenginerecall/random_recall.go
+++ b/service/recall/recallenginerecall/random_recall.go
@@ -104,6 +104,7 @@ func (r *RecallEngineRandomRecall) CloneWithConfig(params map[string]interface{}
 		diversityParam:  recallParams.DiversityParam,
 		customParams:    recallParams.CustomParams,
 		timeout:         recallParams.Timeout,
+		cloneInstances:  make(map[string]*RecallEngineRandomRecall),
 	}
 
 	r.cloneInstances[md5] = recall

--- a/service/recall/recallenginerecall/random_recall.go
+++ b/service/recall/recallenginerecall/random_recall.go
@@ -23,6 +23,7 @@ type RecallEngineRandomRecall struct {
 	recallTableName string
 	diversityParam  string
 	customParams    map[string]interface{}
+	timeout         int
 	client          *recallengine.RecallEngineClient
 	mu              sync.RWMutex
 	cloneInstances  map[string]*RecallEngineRandomRecall
@@ -41,6 +42,7 @@ func NewRecallEngineRandomRecall(client *recallengine.RecallEngineClient, conf r
 		recallTableName: conf.RecallEngineParams[0].RecallTableName,
 		diversityParam:  conf.RecallEngineParams[0].DiversityParam,
 		customParams:    conf.RecallEngineParams[0].CustomParams,
+		timeout:         conf.RecallEngineParams[0].Timeout,
 		client:          client,
 		cloneInstances:  make(map[string]*RecallEngineRandomRecall),
 	}
@@ -57,6 +59,9 @@ func (r *RecallEngineRandomRecall) GetItems(user *module.User, context *context.
 
 func (r *RecallEngineRandomRecall) BuildQueryParams(user *module.User, context *context.RecommendContext) (ret re.RecallConf) {
 	ret.Count = r.returnCount
+	if r.timeout > 0 {
+		ret.Options = &re.RecallOptions{Timeout: r.timeout}
+	}
 	return
 
 }
@@ -98,6 +103,7 @@ func (r *RecallEngineRandomRecall) CloneWithConfig(params map[string]interface{}
 		recallTableName: recallParams.RecallTableName,
 		diversityParam:  recallParams.DiversityParam,
 		customParams:    recallParams.CustomParams,
+		timeout:         recallParams.Timeout,
 	}
 
 	r.cloneInstances[md5] = recall

--- a/service/recall/recallenginerecall/service_recall.go
+++ b/service/recall/recallenginerecall/service_recall.go
@@ -122,6 +122,7 @@ func NewRecallEngineServiceRecall(client *recallengine.RecallEngineClient, conf 
 				diversityParam:  param.DiversityParam,
 				customParams:    param.CustomParams,
 				triggerLimit:    param.TriggerLimit,
+				timeout:         param.Timeout,
 				triggerKey:      NewTriggerKey(&param, client),
 				client:          client,
 				cloneInstances:  make(map[string]*RecallEngineX2IRecall),
@@ -136,6 +137,7 @@ func NewRecallEngineServiceRecall(client *recallengine.RecallEngineClient, conf 
 				recallTableName: param.RecallTableName,
 				diversityParam:  param.DiversityParam,
 				customParams:    param.CustomParams,
+				timeout:         param.Timeout,
 				client:          client,
 				cloneInstances:  make(map[string]*RecallEngineRandomRecall),
 			}
@@ -146,6 +148,7 @@ func NewRecallEngineServiceRecall(client *recallengine.RecallEngineClient, conf 
 				returnCount:    param.Count,
 				scorerClause:   param.ScorerClause,
 				diversityParam: param.DiversityParam,
+				timeout:        param.Timeout,
 				triggerKey:     NewTriggerKey(&param, client),
 				client:         client,
 				cloneInstances: make(map[string]*RecallEngineVectorRecall),

--- a/service/recall/recallenginerecall/vector_recall.go
+++ b/service/recall/recallenginerecall/vector_recall.go
@@ -110,6 +110,7 @@ func (r *RecallEngineVectorRecall) CloneWithConfig(params map[string]interface{}
 		diversityParam: recallParams.DiversityParam,
 		timeout:        recallParams.Timeout,
 		triggerKey:     NewTriggerKey(&recallParams, r.client),
+		cloneInstances: make(map[string]*RecallEngineVectorRecall),
 	}
 
 	r.cloneInstances[md5] = recall

--- a/service/recall/recallenginerecall/vector_recall.go
+++ b/service/recall/recallenginerecall/vector_recall.go
@@ -23,6 +23,7 @@ type RecallEngineVectorRecall struct {
 	//itemIdName      string
 	//recallTableName string
 	diversityParam string
+	timeout        int
 	triggerKey     TriggerKey
 	client         *recallengine.RecallEngineClient
 	mu             sync.RWMutex
@@ -41,6 +42,7 @@ func NewRecallEngineVectorRecall(client *recallengine.RecallEngineClient, conf r
 		recallName:   conf.RecallEngineParams[0].RecallName,
 		//recallTableName: conf.RecallEngineParams[0].RecallTableName,
 		diversityParam: conf.RecallEngineParams[0].DiversityParam,
+		timeout:        conf.RecallEngineParams[0].Timeout,
 		triggerKey:     NewTriggerKey(&conf.RecallEngineParams[0], nil),
 		client:         client,
 		cloneInstances: make(map[string]*RecallEngineVectorRecall),
@@ -64,6 +66,9 @@ func (r *RecallEngineVectorRecall) BuildQueryParams(user *module.User, context *
 	}
 	ret.Trigger = triggerResult.TriggerItem
 	ret.Count = r.returnCount
+	if r.timeout > 0 {
+		ret.Options = &re.RecallOptions{Timeout: r.timeout}
+	}
 	return
 
 }
@@ -103,6 +108,7 @@ func (r *RecallEngineVectorRecall) CloneWithConfig(params map[string]interface{}
 		returnCount:    recallParams.Count,
 		recallName:     r.recallName,
 		diversityParam: recallParams.DiversityParam,
+		timeout:        recallParams.Timeout,
 		triggerKey:     NewTriggerKey(&recallParams, r.client),
 	}
 

--- a/service/recall/recallenginerecall/x2i_recall.go
+++ b/service/recall/recallenginerecall/x2i_recall.go
@@ -25,6 +25,7 @@ type RecallEngineX2IRecall struct {
 	diversityParam  string
 	customParams    map[string]interface{}
 	triggerLimit    int
+	timeout         int
 	triggerKey      TriggerKey
 	client          *recallengine.RecallEngineClient
 	mu              sync.RWMutex
@@ -46,6 +47,7 @@ func NewRecallEngineX2IRecall(client *recallengine.RecallEngineClient, conf recc
 		diversityParam:  conf.RecallEngineParams[0].DiversityParam,
 		customParams:    conf.RecallEngineParams[0].CustomParams,
 		triggerLimit:    conf.RecallEngineParams[0].TriggerLimit,
+		timeout:         conf.RecallEngineParams[0].Timeout,
 		triggerKey:      NewTriggerKey(&conf.RecallEngineParams[0], nil),
 		client:          client,
 		cloneInstances:  make(map[string]*RecallEngineX2IRecall),
@@ -69,8 +71,8 @@ func (r *RecallEngineX2IRecall) BuildQueryParams(user *module.User, context *con
 
 	ret.Trigger = triggerResult.TriggerItem
 	ret.Count = r.returnCount
-	if r.triggerLimit > 0 {
-		ret.Options = &re.RecallOptions{TriggerLimit: r.triggerLimit}
+	if r.triggerLimit > 0 || r.timeout > 0 {
+		ret.Options = &re.RecallOptions{TriggerLimit: r.triggerLimit, Timeout: r.timeout}
 	}
 	return
 
@@ -161,6 +163,7 @@ func (r *RecallEngineX2IRecall) CloneWithConfig(params map[string]interface{}) R
 		diversityParam:  recallParams.DiversityParam,
 		customParams:    recallParams.CustomParams,
 		triggerLimit:    recallParams.TriggerLimit,
+		timeout:         recallParams.Timeout,
 		triggerKey:      NewTriggerKey(&recallParams, r.client),
 		cloneInstances:  make(map[string]*RecallEngineX2IRecall),
 	}


### PR DESCRIPTION
## 背景
召回引擎（recall engine）此前只支持 per-trigger 的 `TriggerLimit`，缺少对单路召回超时（per-way timeout）的控制。本 PR 增加 `Timeout` 支持。

## 改动内容
- **升级 SDK**：`aliyun-pairec-config-go-sdk` 升级到包含 `recallengine.RecallOptions.Timeout` 字段的版本（`v2.1.3-0.20260714015931-6e1064f3fe1a`）。
- **配置**：`RecallEngineParam` 新增 `Timeout int` 字段（单路召回超时，单位毫秒，0 表示不限制）。
- **接入**：X2I / Random / Vector 三路召回的 `BuildQueryParams` 在 `timeout > 0` 时构造 `RecallOptions{Timeout: ...}`；构造函数与 `CloneWithConfig` 同步读取配置。

## 验证
- `go build ./...` 通过。

## 影响范围
- 仅新增字段，默认值 0 表示不限制，向后兼容，不影响未配置该项的现有行为。