### PR TITLE
feat: add PAI token channel

### DIFF
--- a/algorithm/aichat/model.go
+++ b/algorithm/aichat/model.go
@@ -18,7 +18,13 @@ const (
 	defaultPAIModelRegion  = "cn-beijing"
 	defaultPAIModelTimeout = 60000
 	paiModelEndpointFormat = "https://%s.pai-token.aliyuncs.com/v1"
+	paiTokenChannel        = "pairec_agent"
 )
+
+type chatCompletionPayload struct {
+	*ChatCompletionRequest
+	ExtraBody map[string]string `json:"extra_body"`
+}
 
 type Model struct {
 	name     string
@@ -64,7 +70,12 @@ func (m *Model) Stream(ctx context.Context, request *ChatCompletionRequest, onDe
 	}
 	request.Stream = true
 	endpoint := m.endpoint + "/chat/completions"
-	body, err := json.Marshal(request)
+	body, err := json.Marshal(chatCompletionPayload{
+		ChatCompletionRequest: request,
+		ExtraBody: map[string]string{
+			"channel": paiTokenChannel,
+		},
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Add the fixed `pairec_agent` channel identifier to PAI token chat completion requests.
- Inject the identifier at the shared outbound serialization boundary as `extra_body.channel`.
- Keep the public request/config APIs and dependencies unchanged.

## Why

PAI token calls need a stable channel marker for traffic attribution. Central injection ensures both `Run` and `Stream` requests are covered without requiring callers to pass or configure the value.

## Impact

All PAI token chat completion requests emitted by pairec now include:

```json
{
  "extra_body": {
    "channel": "pairec_agent"
  }
}
```

No tests, configuration fields, or dependency changes were added.

## Validation

- `gofmt -d algorithm/aichat/model.go`
- `git diff --check origin/master...HEAD`
- `go test ./algorithm/aichat ./service/aishopping`
- Independent code review: no findings
