### PR TITLE
feat(sort): add DiversityRuleSortV2 with cross-page diversity warmup

### DIFF
--- a/module/diversity_dao.go
+++ b/module/diversity_dao.go
@@ -2,7 +2,9 @@ package module
 
 import (
 	"fmt"
+
 	"github.com/alibaba/pairec/v2/context"
+	"github.com/alibaba/pairec/v2/log"
 	"github.com/alibaba/pairec/v2/recconf"
 )
 
@@ -17,4 +19,26 @@ func NewDiversityDao(config recconf.FilterConfig) DiversityDao {
 	}
 
 	panic(fmt.Sprintf("DiversityDao:not found, name:%s", config.Name))
+}
+
+// NewDiversityDaoByConf creates DiversityDao by the adapter type of the conf.
+// Unlike NewDiversityDao, it returns nil instead of panic when the adapter
+// type is not supported, so the caller can degrade gracefully.
+func NewDiversityDaoByConf(conf recconf.DiversityDaoConfig) DiversityDao {
+	switch conf.AdapterType {
+	case recconf.DataSource_Type_FeatureStore:
+		if dao := NewDiversityFeatureStoreDao(conf); dao != nil {
+			return dao
+		}
+		return nil
+	case recconf.DaoConf_Adapter_Hologres:
+		// reuse the existing constructor, keep its signature untouched
+		if dao := NewDiversityHologresDao(recconf.FilterConfig{DiversityDaoConf: conf}); dao != nil {
+			return dao
+		}
+		return nil
+	default:
+		log.Error(fmt.Sprintf("module=NewDiversityDaoByConf	error=unsupported adapter type:%s", conf.AdapterType))
+		return nil
+	}
 }

--- a/module/diversity_featurestore_dao.go
+++ b/module/diversity_featurestore_dao.go
@@ -1,0 +1,111 @@
+package module
+
+import (
+	"fmt"
+	"time"
+
+	pctx "github.com/alibaba/pairec/v2/context"
+	"github.com/alibaba/pairec/v2/log"
+	"github.com/alibaba/pairec/v2/persist/fs"
+	"github.com/alibaba/pairec/v2/recconf"
+	"github.com/alibaba/pairec/v2/utils"
+	"github.com/goburrow/cache"
+)
+
+type DiversityFeatureStoreDao struct {
+	fsClient       *fs.FSClient
+	table          string
+	distinctFields []string
+	cache          cache.Cache
+}
+
+func NewDiversityFeatureStoreDao(config recconf.DiversityDaoConfig) *DiversityFeatureStoreDao {
+	fsclient, err := fs.GetFeatureStoreClient(config.FeatureStoreName)
+	if err != nil {
+		log.Error(fmt.Sprintf("module=DiversityFeatureStoreDao\terror=%v", err))
+		return nil
+	}
+	cacheTime := 30
+	if config.CacheTimeInMinutes > 0 {
+		cacheTime = config.CacheTimeInMinutes
+	}
+	cacheSize := 100000
+	if config.CacheSize > 0 {
+		cacheSize = config.CacheSize
+	}
+	d := &DiversityFeatureStoreDao{
+		fsClient:       fsclient,
+		table:          config.FeatureStoreViewName,
+		distinctFields: config.DistinctFields,
+		cache:          cache.New(cache.WithMaximumSize(cacheSize), cache.WithExpireAfterWrite(time.Duration(cacheTime)*time.Minute)),
+	}
+	return d
+}
+
+func (d *DiversityFeatureStoreDao) GetDistinctFields() []string {
+	return d.distinctFields
+}
+
+func (d *DiversityFeatureStoreDao) GetDistinctValue(items []*Item, ctx *pctx.RecommendContext) error {
+	itemMap := make(map[ItemId]*Item)
+
+	itemIds := make([]interface{}, 0, len(items))
+	for _, item := range items {
+		if distinct, ok := d.cache.GetIfPresent(item.Id); ok {
+			values := distinct.(map[string]interface{})
+			item.AddProperties(values)
+		} else {
+			itemIds = append(itemIds, string(item.Id))
+			itemMap[item.Id] = item
+		}
+	}
+
+	if len(itemIds) == 0 {
+		return nil
+	}
+
+	featureView := d.fsClient.GetProject().GetFeatureView(d.table)
+	if featureView == nil {
+		err := fmt.Errorf("featureView not found, table:%s", d.table)
+		ctx.LogError(fmt.Sprintf("module=DiversityFeatureStoreDao\terror=%v", err))
+		return err
+	}
+	features, err := featureView.GetOnlineFeatures(itemIds, d.distinctFields, map[string]string{})
+	if err != nil {
+		ctx.LogError(fmt.Sprintf("module=DiversityFeatureStoreDao\terror=featurestore error(%v)", err))
+		return err
+	}
+	featureEntity := d.fsClient.GetProject().GetFeatureEntity(featureView.GetFeatureEntityName())
+	if featureEntity == nil {
+		err := fmt.Errorf("featureEntity not found, name:%s", featureView.GetFeatureEntityName())
+		ctx.LogError(fmt.Sprintf("module=DiversityFeatureStoreDao\terror=%v", err))
+		return err
+	}
+
+	for _, itemFeatures := range features {
+		itemId := ItemId(utils.ToString(itemFeatures[featureEntity.FeatureEntityJoinid], ""))
+		if itemId == "" {
+			continue
+		}
+		distinct := make(map[string]interface{}, len(d.distinctFields))
+		for _, field := range d.distinctFields {
+			if value, ok := itemFeatures[field]; ok && value != nil {
+				// keep raw value, align with FeatureFeatureStoreDao behavior
+				distinct[field] = value
+			}
+		}
+		d.cache.Put(itemId, distinct)
+		if item, ok := itemMap[itemId]; ok {
+			item.AddProperties(distinct)
+		}
+	}
+
+	// negative cache support: cache items not found in featurestore
+	for itemId := range itemMap {
+		if _, ok := d.cache.GetIfPresent(itemId); !ok {
+			d.cache.Put(itemId, map[string]interface{}{})
+		}
+	}
+
+	return nil
+}

--- a/module/diversity_featurestore_dao.go
+++ b/module/diversity_featurestore_dao.go
@@ -82,6 +82,7 @@ func (d *DiversityFeatureStoreDao) GetDistinctValue(items []*Item, ctx *pctx.Rec
 		return err
 	}
 
+	resolved := make(map[ItemId]bool, len(features))
 	for _, itemFeatures := range features {
 		itemId := ItemId(utils.ToString(itemFeatures[featureEntity.FeatureEntityJoinid], ""))
 		if itemId == "" {
@@ -95,14 +96,15 @@ func (d *DiversityFeatureStoreDao) GetDistinctValue(items []*Item, ctx *pctx.Rec
 			}
 		}
 		d.cache.Put(itemId, distinct)
+		resolved[itemId] = true
 		if item, ok := itemMap[itemId]; ok {
 			item.AddProperties(distinct)
 		}
 	}
 
-	// negative cache support: cache items not found in featurestore
+	// negative cache support: only cache items that featurestore did not return
 	for itemId := range itemMap {
-		if _, ok := d.cache.GetIfPresent(itemId); !ok {
+		if !resolved[itemId] {
 			d.cache.Put(itemId, map[string]interface{}{})
 		}
 	}

--- a/module/diversity_hologres_dao.go
+++ b/module/diversity_hologres_dao.go
@@ -96,6 +96,7 @@ func (d *DiversityHologresDao) GetDistinctValue(items []*Item, ctx *pctx.Recomme
 		return err
 	}
 	values := sqlutil.ColumnValues(columns)
+	resolved := make(map[ItemId]bool, len(itemMap))
 	for rows.Next() {
 		if err = rows.Scan(values...); err != nil {
 			ctx.LogError(fmt.Sprintf("module=DiversityHologresDao\tscan err=%v", err))
@@ -126,6 +127,7 @@ func (d *DiversityHologresDao) GetDistinctValue(items []*Item, ctx *pctx.Recomme
 				itemId = ItemId(utils.ToString(key, ""))
 				delete(distinct, d.itemKeyField)
 				d.cache.Put(itemId, distinct)
+				resolved[itemId] = true
 				if item, okey := itemMap[itemId]; okey {
 					item.AddProperties(distinct)
 				}
@@ -133,9 +135,9 @@ func (d *DiversityHologresDao) GetDistinctValue(items []*Item, ctx *pctx.Recomme
 		}
 	}
 
-	// negative cache support: cache items not found in hologres
+	// negative cache support: only cache items that hologres did not return
 	for itemId := range itemMap {
-		if _, ok := d.cache.GetIfPresent(itemId); !ok {
+		if !resolved[itemId] {
 			d.cache.Put(itemId, map[string]interface{}{})
 		}
 	}

--- a/module/diversity_hologres_dao.go
+++ b/module/diversity_hologres_dao.go
@@ -4,17 +4,18 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/goburrow/cache"
-	"github.com/huandu/go-sqlbuilder"
+	"strconv"
+	"strings"
+	"time"
+
 	pctx "github.com/alibaba/pairec/v2/context"
 	"github.com/alibaba/pairec/v2/log"
 	"github.com/alibaba/pairec/v2/persist/holo"
 	"github.com/alibaba/pairec/v2/recconf"
 	"github.com/alibaba/pairec/v2/utils"
 	"github.com/alibaba/pairec/v2/utils/sqlutil"
-	"strconv"
-	"strings"
-	"time"
+	"github.com/goburrow/cache"
+	"github.com/huandu/go-sqlbuilder"
 )
 
 type DiversityHologresDao struct {
@@ -31,16 +32,20 @@ func NewDiversityHologresDao(config recconf.FilterConfig) *DiversityHologresDao 
 		log.Error(fmt.Sprintf("error=%v", err))
 		return nil
 	}
-	cacheTime := 70
+	cacheTime := 30
 	if config.DiversityDaoConf.CacheTimeInMinutes > 0 {
 		cacheTime = config.DiversityDaoConf.CacheTimeInMinutes
+	}
+	cacheSize := 10000000
+	if config.DiversityDaoConf.CacheSize > 0 {
+		cacheSize = config.DiversityDaoConf.CacheSize
 	}
 	d := &DiversityHologresDao{
 		db:             pg.DB,
 		table:          config.DiversityDaoConf.HologresTableName,
 		itemKeyField:   config.DiversityDaoConf.ItemKeyField,
 		distinctFields: config.DiversityDaoConf.DistinctFields,
-		cache:          cache.New(cache.WithMaximumSize(10000000), cache.WithExpireAfterWrite(time.Duration(cacheTime)*time.Minute)),
+		cache:          cache.New(cache.WithMaximumSize(cacheSize), cache.WithExpireAfterWrite(time.Duration(cacheTime)*time.Minute)),
 	}
 	return d
 }
@@ -90,7 +95,6 @@ func (d *DiversityHologresDao) GetDistinctValue(items []*Item, ctx *pctx.Recomme
 		ctx.LogError(fmt.Sprintf("module=DiversityHologresDao\terror=hologres error(%v)", err))
 		return err
 	}
-	count := 0
 	values := sqlutil.ColumnValues(columns)
 	for rows.Next() {
 		if err = rows.Scan(values...); err != nil {
@@ -124,12 +128,17 @@ func (d *DiversityHologresDao) GetDistinctValue(items []*Item, ctx *pctx.Recomme
 				d.cache.Put(itemId, distinct)
 				if item, okey := itemMap[itemId]; okey {
 					item.AddProperties(distinct)
-					count++
 				}
 			}
 		}
 	}
 
-	ctx.LogInfo(fmt.Sprintf("module=DiversityHologresDao\tload %d diversity property", count))
+	// negative cache support: cache items not found in hologres
+	for itemId := range itemMap {
+		if _, ok := d.cache.GetIfPresent(itemId); !ok {
+			d.cache.Put(itemId, map[string]interface{}{})
+		}
+	}
+
 	return nil
 }

--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -878,6 +878,7 @@ type SortConfig struct {
 	TimeInterval            int
 	BoostScoreByWeightDao   BoostScoreByWeightDaoConfig
 	MultiValueDimensionConf []MultiValueDimensionConfig
+	CrossPageDiversity      CrossPageDiversityConfig
 
 	Debug                         bool
 	RemainItem                    bool
@@ -950,6 +951,15 @@ type DiversityDaoConfig struct {
 	ItemKeyField       string
 	DistinctFields     []string
 	CacheTimeInMinutes int
+	CacheSize          int
+}
+
+// CrossPageDiversityConfig warms up the diversity window with the tail items
+// of the previous page, so that diversity rules take effect across pages.
+type CrossPageDiversityConfig struct {
+	Enable           bool
+	LastItemIdsParam string // request param name, default "last_page_item_ids"
+	DiversityDaoConf DiversityDaoConfig
 }
 type AdjustCountConfig struct {
 	RecallName string

--- a/sort/diversity_rule_sort_v2.go
+++ b/sort/diversity_rule_sort_v2.go
@@ -180,29 +180,34 @@ func getLastPageParam(ctx *context.RecommendContext, name string) interface{} {
 }
 
 // parseLastPageItemIds parses item ids from the request parameter value.
-// It supports []interface{}, JSON array string and comma separated string.
+// It supports []interface{}, []string, JSON array string and comma separated
+// string. Invalid JSON array payload returns nil so that the warmup is skipped
+// instead of feeding garbage ids.
 func parseLastPageItemIds(value interface{}) []string {
 	switch v := value.(type) {
 	case []interface{}:
+		return normalizeItemIds(v)
+	case []string:
 		ids := make([]string, 0, len(v))
-		for _, item := range v {
-			if id := utils.ToString(item, ""); id != "" {
+		for _, part := range v {
+			if id := strings.TrimSpace(part); id != "" {
 				ids = append(ids, id)
 			}
 		}
 		return ids
-	case []string:
-		return v
 	case string:
 		str := strings.TrimSpace(v)
 		if str == "" {
 			return nil
 		}
 		if strings.HasPrefix(str, "[") {
-			var ids []string
-			if err := json.Unmarshal([]byte(str), &ids); err == nil {
-				return ids
+			// treat as JSON array, use []interface{} to accept both string and
+			// number elements, no comma split fallback for malformed payload
+			var raw []interface{}
+			if err := json.Unmarshal([]byte(str), &raw); err != nil {
+				return nil
 			}
+			return normalizeItemIds(raw)
 		}
 		parts := strings.Split(str, ",")
 		ids := make([]string, 0, len(parts))
@@ -215,6 +220,17 @@ func parseLastPageItemIds(value interface{}) []string {
 	default:
 		return nil
 	}
+}
+
+// normalizeItemIds converts raw values to trimmed non empty id strings.
+func normalizeItemIds(raw []interface{}) []string {
+	ids := make([]string, 0, len(raw))
+	for _, item := range raw {
+		if id := strings.TrimSpace(utils.ToString(item, "")); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
 }
 
 // warmupCrossPage loads dimension values of the previous page tail items and

--- a/sort/diversity_rule_sort_v2.go
+++ b/sort/diversity_rule_sort_v2.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/alibaba/pairec/v2/context"
@@ -26,6 +27,7 @@ type DiversityRuleSortV2 struct {
 	exclusionRules          []recconf.ExclusionRuleConfig
 	excludeRecallMap        map[string]bool
 	filterParam             *module.FilterParam
+	cloneMutex              sync.RWMutex
 	cloneInstances          map[string]*DiversityRuleSortV2
 	name                    string
 	exploreItemSize         int

--- a/sort/diversity_rule_sort_v2.go
+++ b/sort/diversity_rule_sort_v2.go
@@ -1,0 +1,439 @@
+package sort
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/alibaba/pairec/v2/context"
+	"github.com/alibaba/pairec/v2/log"
+	"github.com/alibaba/pairec/v2/module"
+	"github.com/alibaba/pairec/v2/recconf"
+	"github.com/alibaba/pairec/v2/utils"
+)
+
+const defaultLastItemIdsParam = "last_page_item_ids"
+
+// DiversityRuleSortV2 is a standalone variant of DiversityRuleSort that
+// supports cross page diversity: the tail item ids of the previous page are
+// passed by the client, their dimension values are loaded from the configured
+// datasource and used to warm up the diversity window, so that the first
+// items of the current page are also constrained by the previous page.
+type DiversityRuleSortV2 struct {
+	diversitySize           int
+	diversityRules          []recconf.DiversityRuleConfig
+	exclusionRules          []recconf.ExclusionRuleConfig
+	excludeRecallMap        map[string]bool
+	filterParam             *module.FilterParam
+	cloneInstances          map[string]*DiversityRuleSortV2
+	name                    string
+	exploreItemSize         int
+	multiValueDimensionConf []recconf.MultiValueDimensionConfig
+	multiDimensionMaps      []map[int]recconf.MultiValueDimensionConfig // size is equal config.DiversityRules, per entry is map of multi dimension config for each diversity rule of dimensions
+	lastItemIdsParam        string
+	dimLoader               module.DiversityDao
+	crossPageEnable         bool
+}
+
+func NewDiversityRuleSortV2(config recconf.SortConfig) *DiversityRuleSortV2 {
+	sort := DiversityRuleSortV2{
+		diversitySize:           config.DiversitySize,
+		diversityRules:          config.DiversityRules,
+		exclusionRules:          config.ExclusionRules,
+		excludeRecallMap:        make(map[string]bool, len(config.ExcludeRecalls)),
+		filterParam:             nil,
+		name:                    config.Name,
+		cloneInstances:          make(map[string]*DiversityRuleSortV2),
+		exploreItemSize:         -1,
+		multiValueDimensionConf: config.MultiValueDimensionConf,
+	}
+
+	for _, recallName := range config.ExcludeRecalls {
+		sort.excludeRecallMap[recallName] = true
+	}
+
+	if len(config.Conditions) > 0 {
+		filterParam := module.NewFilterParamWithConfig(config.Conditions)
+		sort.filterParam = filterParam
+	}
+	if config.ExploreItemSize > 0 {
+		sort.exploreItemSize = config.ExploreItemSize
+	}
+	if len(config.MultiValueDimensionConf) > 0 {
+		for _, diversityRuleConfig := range sort.diversityRules {
+			multiDimensionMap := make(map[int]recconf.MultiValueDimensionConfig)
+			for i, dimension := range diversityRuleConfig.Dimensions {
+				for _, multiDimension := range config.MultiValueDimensionConf {
+					if multiDimension.DimensionName == dimension {
+						multiDimensionMap[i] = multiDimension
+						break
+					}
+				}
+			}
+			sort.multiDimensionMaps = append(sort.multiDimensionMaps, multiDimensionMap)
+
+		}
+
+	}
+
+	if config.CrossPageDiversity.Enable {
+		sort.lastItemIdsParam = config.CrossPageDiversity.LastItemIdsParam
+		if sort.lastItemIdsParam == "" {
+			sort.lastItemIdsParam = defaultLastItemIdsParam
+		}
+		sort.dimLoader = module.NewDiversityDaoByConf(config.CrossPageDiversity.DiversityDaoConf)
+		if sort.dimLoader != nil {
+			sort.crossPageEnable = true
+			checkDistinctFieldsCoverage(config, sort.dimLoader.GetDistinctFields())
+		} else {
+			log.Error("module=DiversityRuleSortV2\terror=create diversity dao failed, cross page diversity disabled")
+		}
+	}
+
+	return &sort
+}
+
+// checkDistinctFieldsCoverage warns when some rule dimensions are not covered
+// by the DistinctFields of the dao conf, in which case the history dimension
+// values would be empty strings and the warmup is ineffective for that rule.
+func checkDistinctFieldsCoverage(config recconf.SortConfig, distinctFields []string) {
+	fieldMap := make(map[string]bool, len(distinctFields))
+	for _, field := range distinctFields {
+		fieldMap[field] = true
+	}
+	for _, rule := range config.DiversityRules {
+		for _, dimension := range rule.Dimensions {
+			if !fieldMap[dimension] {
+				log.Warning("module=DiversityRuleSortV2\twarn=dimension " + dimension + " not covered by DistinctFields, cross page warmup is ineffective for it")
+			}
+		}
+	}
+}
+
+func (s *DiversityRuleSortV2) Sort(sortData *SortData) error {
+	if _, ok := sortData.Data.([]*module.Item); !ok {
+		return errors.New("sort data type error")
+	}
+
+	// if condition is empty
+	if s.filterParam == nil {
+		return s.doSort(sortData)
+	} else {
+		userProperties := sortData.User.MakeUserFeatures2()
+		flag, err := s.filterParam.EvaluateByDomain(userProperties, nil)
+		if err != nil {
+			return err
+		}
+		if flag {
+			return s.doSort(sortData)
+		}
+	}
+
+	return nil
+}
+
+func (s *DiversityRuleSortV2) createDiversityRules(size int) (ret []DiversityRuleV2Interface) {
+	for i, config := range s.diversityRules {
+		var rule DiversityRuleV2Interface
+		if len(s.multiValueDimensionConf) > 0 {
+			rule = NewDiversityRuleMultiDimensionV2(config, size, s.multiDimensionMaps[i])
+		} else {
+			rule = NewDiversityRuleV2(config, size)
+		}
+
+		ret = append(ret, rule)
+	}
+
+	return
+}
+
+func (s *DiversityRuleSortV2) createExclusionRules(user *module.User, size int) (ret []*DiversityExclusionRule) {
+	features := make(map[string]any)
+	if user != nil {
+		features = user.MakeUserFeatures2()
+	}
+	for _, config := range s.exclusionRules {
+		rule := NewDiversityExclusionRule(config, features, size)
+		ret = append(ret, rule)
+	}
+
+	return
+}
+
+// getLastPageParam looks up the raw parameter value: first from the top-level
+// request param (custom IParam impls), then from the "features" map which is
+// the standard way to pass custom fields in the recommend API.
+func getLastPageParam(ctx *context.RecommendContext, name string) interface{} {
+	if ctx == nil || ctx.Param == nil {
+		return nil
+	}
+	if value := ctx.GetParameter(name); value != nil {
+		return value
+	}
+	if features, ok := ctx.GetParameter("features").(map[string]interface{}); ok {
+		return features[name]
+	}
+	return nil
+}
+
+// parseLastPageItemIds parses item ids from the request parameter value.
+// It supports []interface{}, JSON array string and comma separated string.
+func parseLastPageItemIds(value interface{}) []string {
+	switch v := value.(type) {
+	case []interface{}:
+		ids := make([]string, 0, len(v))
+		for _, item := range v {
+			if id := utils.ToString(item, ""); id != "" {
+				ids = append(ids, id)
+			}
+		}
+		return ids
+	case []string:
+		return v
+	case string:
+		str := strings.TrimSpace(v)
+		if str == "" {
+			return nil
+		}
+		if strings.HasPrefix(str, "[") {
+			var ids []string
+			if err := json.Unmarshal([]byte(str), &ids); err == nil {
+				return ids
+			}
+		}
+		parts := strings.Split(str, ",")
+		ids := make([]string, 0, len(parts))
+		for _, part := range parts {
+			if id := strings.TrimSpace(part); id != "" {
+				ids = append(ids, id)
+			}
+		}
+		return ids
+	default:
+		return nil
+	}
+}
+
+// warmupCrossPage loads dimension values of the previous page tail items and
+// sets them as the history of each diversity rule. It returns true when at
+// least one rule gets a non empty history.
+func (s *DiversityRuleSortV2) warmupCrossPage(sortData *SortData, diversityRules []DiversityRuleV2Interface) bool {
+	ctx := sortData.Context
+	ids := parseLastPageItemIds(getLastPageParam(ctx, s.lastItemIdsParam))
+	if len(ids) == 0 {
+		return false
+	}
+
+	maxNeed := 0
+	for _, config := range s.diversityRules {
+		if need := historyMaxLen(config); need > maxNeed {
+			maxNeed = need
+		}
+	}
+	if maxNeed <= 0 {
+		return false
+	}
+	if len(ids) > maxNeed {
+		ids = ids[len(ids)-maxNeed:]
+	}
+
+	prevItems := make([]*module.Item, 0, len(ids))
+	for _, id := range ids {
+		prevItems = append(prevItems, module.NewItem(id))
+	}
+
+	if err := s.dimLoader.GetDistinctValue(prevItems, ctx); err != nil {
+		ctx.LogError("module=DiversityRuleSortV2\terror=load prev page dimension failed, skip cross page warmup")
+		return false
+	}
+
+	warmed := false
+	for _, rule := range diversityRules {
+		rule.SetHistory(prevItems)
+		if rule.HistoryLen() > 0 {
+			warmed = true
+		}
+	}
+	return warmed
+}
+
+func (s *DiversityRuleSortV2) doSort(sortData *SortData) error {
+	start := time.Now()
+	items := sortData.Data.([]*module.Item)
+
+	diversityRules := s.createDiversityRules(len(items))
+	if len(diversityRules) == 0 {
+		return nil
+	}
+
+	warmed := false
+	if s.crossPageEnable && s.dimLoader != nil {
+		warmed = s.warmupCrossPage(sortData, diversityRules)
+	}
+
+	exclusionRules := s.createExclusionRules(sortData.User, len(items))
+	var excludeItems []*module.Item
+	if len(s.excludeRecallMap) > 0 {
+		newItems := make([]*module.Item, 0, len(items))
+		for _, item := range items {
+			if _, ok := s.excludeRecallMap[item.GetRecallName()]; ok {
+				excludeItems = append(excludeItems, item)
+			} else {
+				newItems = append(newItems, item)
+			}
+		}
+
+		items = newItems
+	}
+
+	itemLength := len(items)
+	//if items empty
+	if itemLength == 0 {
+		return nil
+	}
+
+	diversitySize := sortData.Context.Size
+
+	if s.diversitySize > 0 {
+		diversitySize = s.diversitySize
+		if diversitySize > itemLength {
+			diversitySize = itemLength
+		}
+	}
+
+	result := make([]*module.Item, 0, diversitySize)
+	alreadyMatchItems := make(map[module.ItemId]bool, diversitySize)
+	exFlag := false
+	index := 0
+	// when warmed, the seed item is not appended unconditionally: the main
+	// loop below matches every item (including the first one) against the
+	// history prefix, and it has its own weight/first-item fallback.
+	if !warmed {
+		if len(exclusionRules) > 0 {
+			for _, item := range items {
+				exFlag = false
+				for _, rule := range exclusionRules {
+					if rule.Match(1, item) {
+						exFlag = true
+						break
+					}
+				}
+				if !exFlag { // item not match any exclusion rule
+					alreadyMatchItems[item.Id] = true
+					result = append(result, item)
+					break
+				}
+			}
+
+			if len(result) == 0 {
+				alreadyMatchItems[items[0].Id] = true
+				result = append(result, items[0])
+				items = items[1:]
+			}
+
+		} else {
+			alreadyMatchItems[items[0].Id] = true
+			result = append(result, items[0])
+			items = items[1:]
+		}
+		index = 1
+	}
+
+	weight := 0
+	itemWeightContainer := itemWeightContainerPool.Get().(*itemWeightContainer)
+	defer itemWeightContainerPool.Put(itemWeightContainer)
+	hasWeight := false
+	for _, rule := range diversityRules {
+		if rule.GetWeight() > 0 {
+			hasWeight = true
+			break
+		}
+	}
+	for len(result) <= diversitySize {
+		if index == itemLength {
+			break
+		}
+
+		flag := true
+		// if all the rest items not match diversity rule, use the first item append to the result
+		firstItemIndex := -1
+		itemWeightContainer.reset()
+		for i, item := range items {
+			if _, ok := alreadyMatchItems[item.Id]; ok {
+				continue
+			}
+			if len(exclusionRules) > 0 {
+				exFlag = false
+				for _, rule := range exclusionRules {
+					if rule.Match(len(result)+1, item) { // next position check item is match the exclusion rule
+						exFlag = true
+						break
+					}
+				}
+				if exFlag { // if item match the exclusion rule, so skip it, search next item
+					continue
+				}
+			}
+
+			if firstItemIndex == -1 {
+				firstItemIndex = i
+			}
+			if s.exploreItemSize > 0 && i-firstItemIndex >= s.exploreItemSize {
+				break
+			}
+			flag = true
+			weight = 0
+			for _, rule := range diversityRules {
+				if hasWeight { // if has weight, so need to iterate all the rules find the max weight
+					if rule.Match(item, result) {
+						weight += rule.GetWeight()
+					} else {
+						flag = false
+					}
+				} else {
+					if flag = rule.Match(item, result); !flag {
+						break
+					}
+				}
+			}
+
+			// if the item match all the diversity rule, so add it to the result
+			if flag {
+				alreadyMatchItems[item.Id] = true
+				result = append(result, item)
+				index++
+				break
+			} else {
+				itemWeightContainer.addItemWeight(item, weight)
+			}
+		}
+
+		if !flag {
+			if item := itemWeightContainer.getItem(); item != nil {
+				alreadyMatchItems[item.Id] = true
+				result = append(result, item)
+				index++
+			} else {
+				alreadyMatchItems[items[firstItemIndex].Id] = true
+				result = append(result, items[firstItemIndex])
+				index++
+			}
+		} else if firstItemIndex == -1 { // all items are in alreadyMatchItems map
+			break
+		}
+	}
+
+	for _, item := range items {
+		if _, ok := alreadyMatchItems[item.Id]; ok {
+			continue
+		}
+		result = append(result, item)
+	}
+
+	result = append(result, excludeItems...)
+
+	sortData.Data = result
+	sortInfoLogWithName(sortData, "DiversityRuleSortV2", s.name, len(result), start)
+	return nil
+}

--- a/sort/diversity_rule_sort_v2_clone.go
+++ b/sort/diversity_rule_sort_v2_clone.go
@@ -31,16 +31,15 @@ func (s *DiversityRuleSortV2) CloneWithConfig(params map[string]interface{}) ISo
 	}
 	s.cloneMutex.RUnlock()
 
-	sort := NewDiversityRuleSortV2(config)
-	if sort != nil {
-		s.cloneMutex.Lock()
-		if existing, ok := s.cloneInstances[md5]; ok {
-			s.cloneMutex.Unlock()
-			return existing
-		}
-		s.cloneInstances[md5] = sort
-		s.cloneMutex.Unlock()
+	// create under the write lock so that concurrent misses on the same md5
+	// never build duplicated instances (the dao cache holds goroutine resource)
+	s.cloneMutex.Lock()
+	defer s.cloneMutex.Unlock()
+	if sort, ok := s.cloneInstances[md5]; ok {
+		return sort
 	}
+	sort := NewDiversityRuleSortV2(config)
+	s.cloneInstances[md5] = sort
 	return sort
 }
 

--- a/sort/diversity_rule_sort_v2_clone.go
+++ b/sort/diversity_rule_sort_v2_clone.go
@@ -24,13 +24,22 @@ func (s *DiversityRuleSortV2) CloneWithConfig(params map[string]interface{}) ISo
 
 	d, _ := json.Marshal(config)
 	md5 := utils.Md5(string(d))
+	s.cloneMutex.RLock()
 	if sort, ok := s.cloneInstances[md5]; ok {
+		s.cloneMutex.RUnlock()
 		return sort
 	}
+	s.cloneMutex.RUnlock()
 
 	sort := NewDiversityRuleSortV2(config)
 	if sort != nil {
+		s.cloneMutex.Lock()
+		if existing, ok := s.cloneInstances[md5]; ok {
+			s.cloneMutex.Unlock()
+			return existing
+		}
 		s.cloneInstances[md5] = sort
+		s.cloneMutex.Unlock()
 	}
 	return sort
 }

--- a/sort/diversity_rule_sort_v2_clone.go
+++ b/sort/diversity_rule_sort_v2_clone.go
@@ -1,0 +1,40 @@
+package sort
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/alibaba/pairec/v2/log"
+	"github.com/alibaba/pairec/v2/recconf"
+	"github.com/alibaba/pairec/v2/utils"
+)
+
+func (s *DiversityRuleSortV2) CloneWithConfig(params map[string]interface{}) ISort {
+	j, err := json.Marshal(params)
+	if err != nil {
+		log.Error(fmt.Sprintf("event=CloneWithConfig\terror=%v", err))
+		return s
+	}
+
+	config := recconf.SortConfig{}
+	if err := json.Unmarshal(j, &config); err != nil {
+		log.Error(fmt.Sprintf("event=CloneWithConfig\terror=%v", err))
+		return s
+	}
+
+	d, _ := json.Marshal(config)
+	md5 := utils.Md5(string(d))
+	if sort, ok := s.cloneInstances[md5]; ok {
+		return sort
+	}
+
+	sort := NewDiversityRuleSortV2(config)
+	if sort != nil {
+		s.cloneInstances[md5] = sort
+	}
+	return sort
+}
+
+func (s *DiversityRuleSortV2) GetSortName() string {
+	return s.name
+}

--- a/sort/diversity_rule_sort_v2_test.go
+++ b/sort/diversity_rule_sort_v2_test.go
@@ -142,12 +142,14 @@ func TestParseLastPageItemIds(t *testing.T) {
 	assert.Equal(t, []string{"1", "2", "3"}, parseLastPageItemIds([]interface{}{"1", "2", "3"}))
 	assert.Equal(t, []string{"1", "2"}, parseLastPageItemIds([]interface{}{"1", 2}))
 	assert.Equal(t, []string{"1", "2"}, parseLastPageItemIds(`["1","2"]`))
+	assert.Equal(t, []string{"1", "2"}, parseLastPageItemIds(`[1,2]`)) // json number elements
 	assert.Equal(t, []string{"1", "2"}, parseLastPageItemIds("1, 2"))
+	assert.Equal(t, []string{"1", "2"}, parseLastPageItemIds([]string{" 1 ", "", "2"}))
 	assert.Equal(t, 0, len(parseLastPageItemIds("")))
 	assert.Equal(t, 0, len(parseLastPageItemIds(nil)))
 	assert.Equal(t, 0, len(parseLastPageItemIds(123)))
-	// invalid json degrades to comma split
-	assert.Equal(t, []string{"[1", "2"}, parseLastPageItemIds("[1,2"))
+	// malformed json array payload is dropped instead of comma split
+	assert.Equal(t, 0, len(parseLastPageItemIds("[1,2")))
 }
 
 func buildCrossPageSortV2(config recconf.SortConfig, dao module.DiversityDao) *DiversityRuleSortV2 {

--- a/sort/diversity_rule_sort_v2_test.go
+++ b/sort/diversity_rule_sort_v2_test.go
@@ -1,0 +1,297 @@
+package sort
+
+import (
+	"strconv"
+	"testing"
+
+	"fortio.org/assert"
+	"github.com/alibaba/pairec/v2/context"
+	"github.com/alibaba/pairec/v2/module"
+	"github.com/alibaba/pairec/v2/recconf"
+)
+
+// mockSortParam mimics the standard RecommendParam: only the "features" name
+// is exposed, custom fields must be looked up inside the features map.
+type mockSortParam struct {
+	features map[string]interface{}
+}
+
+func (p *mockSortParam) GetParameter(name string) interface{} {
+	if name == "features" {
+		return p.features
+	}
+	return nil
+}
+
+// stubDiversityDao returns preset dimension values without any datasource.
+type stubDiversityDao struct {
+	values map[string]map[string]interface{}
+	fields []string
+}
+
+func (d *stubDiversityDao) GetDistinctValue(items []*module.Item, ctx *context.RecommendContext) error {
+	for _, item := range items {
+		if vals, ok := d.values[string(item.Id)]; ok {
+			item.AddProperties(vals)
+		}
+	}
+	return nil
+}
+
+func (d *stubDiversityDao) GetDistinctFields() []string {
+	return d.fields
+}
+
+func newTagItem(id, tag string) *module.Item {
+	item := module.NewItem(id)
+	item.RetrieveId = "r1"
+	item.AddProperty("tag", tag)
+	return item
+}
+
+func TestDiversityRuleV2MatchWithHistory(t *testing.T) {
+	t.Run("interval_size_cross_history", func(t *testing.T) {
+		rule := NewDiversityRuleV2(recconf.DiversityRuleConfig{
+			Dimensions:   []string{"tag"},
+			IntervalSize: 2,
+		}, 10)
+		rule.SetHistory([]*module.Item{newTagItem("p1", "t1"), newTagItem("p2", "t1")})
+		assert.Equal(t, 2, rule.HistoryLen())
+
+		// result is empty, but the history tail has 2 consecutive "t1"
+		assert.Equal(t, false, rule.Match(newTagItem("c1", "t1"), nil))
+		assert.Equal(t, true, rule.Match(newTagItem("c2", "t2"), nil))
+	})
+
+	t.Run("window_size_cross_history", func(t *testing.T) {
+		rule := NewDiversityRuleV2(recconf.DiversityRuleConfig{
+			Dimensions:    []string{"tag"},
+			WindowSize:    6,
+			FrequencySize: 1,
+		}, 10)
+		rule.SetHistory([]*module.Item{
+			newTagItem("p1", "t9"), newTagItem("p2", "t8"), newTagItem("p3", "t1"),
+			newTagItem("p4", "t7"), newTagItem("p5", "t6"),
+		})
+		assert.Equal(t, 5, rule.HistoryLen())
+
+		// "t1" appears in the history window -> frequency exceeded
+		assert.Equal(t, false, rule.Match(newTagItem("c1", "t1"), nil))
+		assert.Equal(t, true, rule.Match(newTagItem("c2", "t2"), nil))
+
+		// window slides as result grows: with 3 items in result, only the
+		// last 2 history values (t7, t6) stay in the window of size 6
+		result := []*module.Item{newTagItem("r1", "a"), newTagItem("r2", "b"), newTagItem("r3", "c")}
+		assert.Equal(t, true, rule.Match(newTagItem("c3", "t1"), result))
+		assert.Equal(t, false, rule.Match(newTagItem("c4", "t7"), result))
+	})
+
+	t.Run("history_truncated_to_max_len", func(t *testing.T) {
+		rule := NewDiversityRuleV2(recconf.DiversityRuleConfig{
+			Dimensions:    []string{"tag"},
+			WindowSize:    3,
+			FrequencySize: 1,
+		}, 10)
+		var prevItems []*module.Item
+		for i := 0; i < 8; i++ {
+			prevItems = append(prevItems, newTagItem("p"+strconv.Itoa(i), "t"+strconv.Itoa(i)))
+		}
+		rule.SetHistory(prevItems)
+		// maxLen = WindowSize - 1 = 2, only the last 2 are kept
+		assert.Equal(t, 2, rule.HistoryLen())
+		assert.Equal(t, false, rule.Match(newTagItem("c1", "t7"), nil))
+		assert.Equal(t, true, rule.Match(newTagItem("c2", "t0"), nil))
+	})
+
+	t.Run("empty_history_equals_v1", func(t *testing.T) {
+		config := recconf.DiversityRuleConfig{
+			Dimensions:    []string{"tag"},
+			WindowSize:    4,
+			FrequencySize: 2,
+			IntervalSize:  1,
+		}
+		v1 := NewDiversityRule(config, 10)
+		v2 := NewDiversityRuleV2(config, 10)
+
+		var result []*module.Item
+		for _, tag := range []string{"t1", "t2", "t1", "t1", "t2", "t3"} {
+			item := newTagItem("i"+strconv.Itoa(len(result)), tag)
+			assert.Equal(t, v1.Match(item, result), v2.Match(item, result))
+			result = append(result, item)
+		}
+	})
+}
+
+func TestDiversityRuleMultiDimensionV2MatchWithHistory(t *testing.T) {
+	multiDimensionMap := map[int]recconf.MultiValueDimensionConfig{
+		0: {DimensionName: "tag", Delimiter: "/"},
+	}
+	rule := NewDiversityRuleMultiDimensionV2(recconf.DiversityRuleConfig{
+		Dimensions:   []string{"tag"},
+		IntervalSize: 1,
+	}, 10, multiDimensionMap)
+	rule.SetHistory([]*module.Item{newTagItem("p1", "b/c")})
+	assert.Equal(t, 1, rule.HistoryLen())
+
+	// "a/b" intersects with history tail "b/c" -> rejected
+	assert.Equal(t, false, rule.Match(newTagItem("c1", "a/b"), nil))
+	assert.Equal(t, true, rule.Match(newTagItem("c2", "d/e"), nil))
+}
+
+func TestParseLastPageItemIds(t *testing.T) {
+	assert.Equal(t, []string{"1", "2", "3"}, parseLastPageItemIds([]interface{}{"1", "2", "3"}))
+	assert.Equal(t, []string{"1", "2"}, parseLastPageItemIds([]interface{}{"1", 2}))
+	assert.Equal(t, []string{"1", "2"}, parseLastPageItemIds(`["1","2"]`))
+	assert.Equal(t, []string{"1", "2"}, parseLastPageItemIds("1, 2"))
+	assert.Equal(t, 0, len(parseLastPageItemIds("")))
+	assert.Equal(t, 0, len(parseLastPageItemIds(nil)))
+	assert.Equal(t, 0, len(parseLastPageItemIds(123)))
+	// invalid json degrades to comma split
+	assert.Equal(t, []string{"[1", "2"}, parseLastPageItemIds("[1,2"))
+}
+
+func buildCrossPageSortV2(config recconf.SortConfig, dao module.DiversityDao) *DiversityRuleSortV2 {
+	s := NewDiversityRuleSortV2(config)
+	s.crossPageEnable = true
+	s.lastItemIdsParam = defaultLastItemIdsParam
+	s.dimLoader = dao
+	return s
+}
+
+func TestDiversityRuleSortV2CrossPage(t *testing.T) {
+	config := recconf.SortConfig{
+		DiversityRules: []recconf.DiversityRuleConfig{
+			{
+				Dimensions:   []string{"tag"},
+				IntervalSize: 2,
+			},
+		},
+	}
+	dao := &stubDiversityDao{
+		values: map[string]map[string]interface{}{
+			"p1": {"tag": "t1"},
+			"p2": {"tag": "t1"},
+		},
+		fields: []string{"tag"},
+	}
+
+	newItems := func() []*module.Item {
+		var items []*module.Item
+		for i := 0; i < 6; i++ {
+			tag := "t1"
+			if i >= 3 {
+				tag = "t2"
+			}
+			items = append(items, newTagItem(strconv.Itoa(i), tag))
+		}
+		return items
+	}
+
+	t.Run("warmup_constrains_first_item", func(t *testing.T) {
+		ctx := context.NewRecommendContext()
+		ctx.Size = 6
+		ctx.Param = &mockSortParam{features: map[string]interface{}{
+			"last_page_item_ids": []interface{}{"p1", "p2"},
+		}}
+		sortData := SortData{Data: newItems(), Context: ctx}
+
+		err := buildCrossPageSortV2(config, dao).Sort(&sortData)
+		assert.Equal(t, nil, err)
+
+		result := sortData.Data.([]*module.Item)
+		// history tail has 2 consecutive "t1" and IntervalSize=2, so the
+		// first item of this page must not be "t1"
+		assert.Equal(t, "t2", result[0].StringProperty("tag"))
+	})
+
+	t.Run("no_param_behaves_like_v1", func(t *testing.T) {
+		ctx := context.NewRecommendContext()
+		ctx.Size = 6
+		ctx.Param = &mockSortParam{features: map[string]interface{}{}}
+		sortData := SortData{Data: newItems(), Context: ctx}
+
+		err := buildCrossPageSortV2(config, dao).Sort(&sortData)
+		assert.Equal(t, nil, err)
+
+		result := sortData.Data.([]*module.Item)
+		assert.Equal(t, "0", string(result[0].Id))
+	})
+}
+
+// TestDiversityRuleSortV2Alignment verifies that V2 without cross page config
+// produces exactly the same order as V1 for the same input.
+func TestDiversityRuleSortV2Alignment(t *testing.T) {
+	configs := []recconf.SortConfig{
+		{
+			DiversityRules: []recconf.DiversityRuleConfig{
+				{Dimensions: []string{"tag"}, IntervalSize: 1},
+			},
+		},
+		{
+			DiversityRules: []recconf.DiversityRuleConfig{
+				{Dimensions: []string{"tag"}, WindowSize: 4, FrequencySize: 2},
+			},
+		},
+		{
+			DiversityRules: []recconf.DiversityRuleConfig{
+				{Dimensions: []string{"tag"}, IntervalSize: 2, Weight: 10},
+				{Dimensions: []string{"category"}, WindowSize: 3, FrequencySize: 1, Weight: 5},
+			},
+		},
+		{
+			DiversityRules: []recconf.DiversityRuleConfig{
+				{Dimensions: []string{"tag"}, WindowSize: 5, FrequencySize: 1},
+			},
+			MultiValueDimensionConf: []recconf.MultiValueDimensionConfig{
+				{DimensionName: "tag", Delimiter: "/"},
+			},
+		},
+	}
+
+	newItems := func() []*module.Item {
+		var items []*module.Item
+		tags := []string{"t1/a", "t1/b", "t2/a", "t1/a", "t3/c", "t2/b", "t1/c", "t3/a", "t2/c", "t1/b"}
+		for i, tag := range tags {
+			item := module.NewItem(strconv.Itoa(i))
+			item.RetrieveId = "r1"
+			item.AddProperty("tag", tag)
+			item.AddProperty("category", "c"+strconv.Itoa(i%3))
+			items = append(items, item)
+		}
+		return items
+	}
+
+	for i, config := range configs {
+		ctxV1 := context.NewRecommendContext()
+		ctxV1.Size = 10
+		sortDataV1 := SortData{Data: newItems(), Context: ctxV1}
+		if err := NewDiversityRuleSort(config).Sort(&sortDataV1); err != nil {
+			t.Fatalf("config %d v1 sort error: %v", i, err)
+		}
+
+		ctxV2 := context.NewRecommendContext()
+		ctxV2.Size = 10
+		sortDataV2 := SortData{Data: newItems(), Context: ctxV2}
+		if err := NewDiversityRuleSortV2(config).Sort(&sortDataV2); err != nil {
+			t.Fatalf("config %d v2 sort error: %v", i, err)
+		}
+
+		resultV1 := sortDataV1.Data.([]*module.Item)
+		resultV2 := sortDataV2.Data.([]*module.Item)
+		assert.Equal(t, len(resultV1), len(resultV2))
+		for j := range resultV1 {
+			if resultV1[j].Id != resultV2[j].Id {
+				t.Fatalf("config %d result mismatch at %d: v1=%s v2=%s", i, j, resultV1[j].Id, resultV2[j].Id)
+			}
+		}
+	}
+}
+
+// TestNewDiversityDaoByConfUnknownType ensures the factory degrades to nil
+// instead of panicking for unsupported adapter types.
+func TestNewDiversityDaoByConfUnknownType(t *testing.T) {
+	dao := module.NewDiversityDaoByConf(recconf.DiversityDaoConfig{
+		DaoConfig: recconf.DaoConfig{AdapterType: "unknown"},
+	})
+	assert.Equal(t, nil, dao)
+}

--- a/sort/diversity_rule_v2.go
+++ b/sort/diversity_rule_v2.go
@@ -1,0 +1,201 @@
+package sort
+
+import (
+	"github.com/alibaba/pairec/v2/module"
+	"github.com/alibaba/pairec/v2/recconf"
+)
+
+// DiversityRuleV2Interface extends the V1 match semantics with a history
+// prefix, so that diversity rules can take effect across pages. The history
+// items are virtually placed before the result list when matching.
+type DiversityRuleV2Interface interface {
+	Match(item *module.Item, itemList []*module.Item) bool
+	GetWeight() int
+	SetHistory(prevItems []*module.Item) // warm up window with prev page tail items
+	HistoryLen() int                     // 0 means no history
+}
+
+// historyMaxLen returns the max count of history items that can influence
+// the match result of the given rule config.
+func historyMaxLen(config recconf.DiversityRuleConfig) int {
+	maxLen := 0
+	if config.WindowSize > 0 && config.FrequencySize > 0 && config.WindowSize > config.FrequencySize {
+		maxLen = config.WindowSize - 1
+	}
+	if config.IntervalSize > maxLen {
+		maxLen = config.IntervalSize
+	}
+	return maxLen
+}
+
+var _ DiversityRuleV2Interface = (*DiversityRuleV2)(nil)
+
+// DiversityRuleV2 embeds the V1 rule to reuse dimension value evaluation and
+// its cache, and only overrides Match to scan across the history prefix.
+type DiversityRuleV2 struct {
+	*DiversityRule
+	historyValues []string // prev page tail dimension values, oldest first
+}
+
+func NewDiversityRuleV2(config recconf.DiversityRuleConfig, size int) *DiversityRuleV2 {
+	return &DiversityRuleV2{
+		DiversityRule: NewDiversityRule(config, size),
+	}
+}
+
+func (r *DiversityRuleV2) SetHistory(prevItems []*module.Item) {
+	maxLen := historyMaxLen(r.DiversityRuleConfig)
+	if maxLen <= 0 || len(prevItems) == 0 {
+		return
+	}
+	if len(prevItems) > maxLen {
+		prevItems = prevItems[len(prevItems)-maxLen:]
+	}
+	r.historyValues = make([]string, 0, len(prevItems))
+	for _, item := range prevItems {
+		r.historyValues = append(r.historyValues, r.GetDimensionValue(item))
+	}
+}
+
+func (r *DiversityRuleV2) HistoryLen() int {
+	return len(r.historyValues)
+}
+
+// valueAt returns the dimension value at virtual position i of the sequence
+// historyValues ++ itemList.
+func (r *DiversityRuleV2) valueAt(i int, itemList []*module.Item) string {
+	if i < len(r.historyValues) {
+		return r.historyValues[i]
+	}
+	return r.GetDimensionValue(itemList[i-len(r.historyValues)])
+}
+
+// Match is identical to the V1 DiversityRule.Match when historyValues is
+// empty; otherwise the history prefix is included in the scan window.
+func (r *DiversityRuleV2) Match(item *module.Item, itemList []*module.Item) bool {
+	size := len(itemList) + len(r.historyValues)
+
+	itemDimensionValue := r.GetDimensionValue(item)
+	if r.DiversityRuleConfig.IntervalSize > 0 && size >= r.DiversityRuleConfig.IntervalSize {
+		end := size
+		begin := size - r.DiversityRuleConfig.IntervalSize
+		sameValue := 1
+		for i := end - 1; i >= begin; i-- {
+			if itemDimensionValue == r.valueAt(i, itemList) {
+				sameValue++
+			} else {
+				break
+			}
+		}
+
+		if sameValue > r.DiversityRuleConfig.IntervalSize {
+			return false
+		}
+
+	}
+	if r.DiversityRuleConfig.WindowSize > 0 &&
+		r.DiversityRuleConfig.FrequencySize > 0 &&
+		r.DiversityRuleConfig.WindowSize > r.DiversityRuleConfig.FrequencySize {
+		end := size
+		begin := size - r.DiversityRuleConfig.WindowSize + 1
+		if begin < 0 {
+			begin = 0
+		}
+
+		sameValue := 1
+		for i := begin; i < end; i++ {
+			if itemDimensionValue == r.valueAt(i, itemList) {
+				sameValue++
+			}
+
+			if sameValue > r.DiversityRuleConfig.FrequencySize {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+var _ DiversityRuleV2Interface = (*DiversityRuleMultiDimensionV2)(nil)
+
+// DiversityRuleMultiDimensionV2 is the multi value dimension variant, it
+// reuses the V1 dimension evaluation (delimiter split) and equality check.
+type DiversityRuleMultiDimensionV2 struct {
+	*DiversityRuleMultiDimension
+	historyValues [][]any // prev page tail dimension values, oldest first
+}
+
+func NewDiversityRuleMultiDimensionV2(config recconf.DiversityRuleConfig, size int, multiDimensionMap map[int]recconf.MultiValueDimensionConfig) *DiversityRuleMultiDimensionV2 {
+	return &DiversityRuleMultiDimensionV2{
+		DiversityRuleMultiDimension: NewDiversityRuleMultiDimension(config, size, multiDimensionMap),
+	}
+}
+
+func (r *DiversityRuleMultiDimensionV2) SetHistory(prevItems []*module.Item) {
+	maxLen := historyMaxLen(r.DiversityRuleConfig)
+	if maxLen <= 0 || len(prevItems) == 0 {
+		return
+	}
+	if len(prevItems) > maxLen {
+		prevItems = prevItems[len(prevItems)-maxLen:]
+	}
+	r.historyValues = make([][]any, 0, len(prevItems))
+	for _, item := range prevItems {
+		r.historyValues = append(r.historyValues, r.GetDimensionValue(item))
+	}
+}
+
+func (r *DiversityRuleMultiDimensionV2) HistoryLen() int {
+	return len(r.historyValues)
+}
+
+func (r *DiversityRuleMultiDimensionV2) valueAt(i int, itemList []*module.Item) []any {
+	if i < len(r.historyValues) {
+		return r.historyValues[i]
+	}
+	return r.GetDimensionValue(itemList[i-len(r.historyValues)])
+}
+
+func (r *DiversityRuleMultiDimensionV2) Match(item *module.Item, itemList []*module.Item) bool {
+	size := len(itemList) + len(r.historyValues)
+
+	itemDimensionValues := r.GetDimensionValue(item)
+	if r.DiversityRuleConfig.IntervalSize > 0 && size >= r.DiversityRuleConfig.IntervalSize {
+		end := size
+		begin := size - r.DiversityRuleConfig.IntervalSize
+		sameValue := 1
+		for i := end - 1; i >= begin; i-- {
+			if r.isDimensionValuesEqual(itemDimensionValues, r.valueAt(i, itemList)) {
+				sameValue++
+			} else {
+				break
+			}
+		}
+
+		if sameValue > r.DiversityRuleConfig.IntervalSize {
+			return false
+		}
+
+	}
+	if r.DiversityRuleConfig.WindowSize > 0 &&
+		r.DiversityRuleConfig.FrequencySize > 0 &&
+		r.DiversityRuleConfig.WindowSize > r.DiversityRuleConfig.FrequencySize {
+		end := size
+		begin := size - r.DiversityRuleConfig.WindowSize + 1
+		if begin < 0 {
+			begin = 0
+		}
+
+		sameValue := 1
+		for i := begin; i < end; i++ {
+			if r.isDimensionValuesEqual(itemDimensionValues, r.valueAt(i, itemList)) {
+				sameValue++
+			}
+
+			if sameValue > r.DiversityRuleConfig.FrequencySize {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/sort/sort.go
+++ b/sort/sort.go
@@ -179,6 +179,8 @@ func RegisterSortWithConfig(config *recconf.RecommendConfig) {
 			s = NewBoostScoreSort(conf)
 		} else if conf.SortType == "DiversityRuleSort" {
 			s = NewDiversityRuleSort(conf)
+		} else if conf.SortType == "DiversityRuleSortV2" {
+			s = NewDiversityRuleSortV2(conf)
 		} else if conf.SortType == "AlgoScoreSort" {
 			s = NewAlgoScoreSort(conf)
 		} else if conf.SortType == "TrafficControlSort" {


### PR DESCRIPTION
## Summary

Add a new `DiversityRuleSortV2` sort plugin that pre-warms the diversity scatter window with the tail items of the previous page, so same-category clustering across page boundaries is avoided. The existing `DiversityRuleSort` (V1) is kept completely untouched.

## Design

- **Virtual sequence match**: `DiversityRuleV2` / `DiversityRuleMultiDimensionV2` evaluate window/interval/frequency rules against `history prefix + current result`. With empty history the behavior is line-by-line identical to V1.
- **Seed handling**: when warmup succeeds, the unconditional seed item is skipped so the first item of the page also goes through diversity rules (exclusion rules still apply via the main loop position check).
- **Request contract**: the client passes `last_page_item_ids` (configurable via `LastItemIdsParam`) through the `features` field of the recommend request; a two-level lookup also supports custom `IParam` implementations.
- **Dimension backfill**: new `DiversityFeatureStoreDao` and `NewDiversityDaoByConf` factory (FeatureStore / Hologres) load distinct fields for last-page items, with local cache (default 30 min / 100k entries, configurable) and negative caching for missing items.
- **Degradation**: any failure (param missing, dao init/query error) silently falls back to V1 behavior.

## Config example

```json
{
  "SortType": "DiversityRuleSortV2",
  "CrossPageDiversity": {
    "Enable": true,
    "LastItemIdsParam": "last_page_item_ids",
    "DiversityDaoConf": {
      "AdapterType": "featurestore",
      "FeatureStoreName": "fs-project",
      "FeatureStoreViewName": "item_feature_view",
      "DistinctFields": ["category_l3"]
    }
  }
}
```

## Tests

- V1/V2 alignment regression: 4 configs (weight, multi rules, multi-value dimension), outputs identical position by position
- Cross-page end-to-end: after warmup the first item of the page is constrained by history; without the param it degrades to V1 behavior
- `parseLastPageItemIds` 7 branches, dao factory unknown type returns nil without panic
- `go build ./...`, `go vet`, `go test ./sort/ ./module/ ./filter/ ./recconf/` all pass