### PR TITLE
feat: support item property aggregation and trigger time window for u2i_realtime recall

### DIFF
--- a/module/item2x_dao.go
+++ b/module/item2x_dao.go
@@ -1,0 +1,72 @@
+package module
+
+import (
+	"time"
+
+	"github.com/alibaba/pairec/v2/context"
+	"github.com/alibaba/pairec/v2/recconf"
+	"github.com/goburrow/cache"
+)
+
+// Item2XDao gets item property(x) values by item ids from an item attribute table.
+type Item2XDao interface {
+	// ListItem2X returns itemId => raw property value, the value is not split by delimiter
+	ListItem2X(itemIds []string, context *context.RecommendContext) map[string]string
+}
+
+// NewItem2XDao creates Item2XDao by the adapter type of Item2XConfig
+func NewItem2XDao(config recconf.Item2XConfig) Item2XDao {
+	if config.AdapterType == recconf.DaoConf_Adapter_Hologres {
+		return NewItem2XHologresDao(config)
+	} else if config.AdapterType == recconf.DataSource_Type_FeatureStore {
+		return NewItem2XFeatureStoreDao(config)
+	}
+
+	panic("Item2XDao not implement, adapterType:" + config.AdapterType)
+}
+
+// newItem2XCache creates the local cache of itemId => property value by config,
+// returns nil if CacheSize is not configured
+func newItem2XCache(config recconf.Item2XConfig) cache.Cache {
+	if config.CacheSize <= 0 {
+		return nil
+	}
+	cacheTime := 3600
+	if config.CacheTime > 0 {
+		cacheTime = config.CacheTime
+	}
+	return cache.New(cache.WithMaximumSize(config.CacheSize),
+		cache.WithExpireAfterWrite(time.Second*time.Duration(cacheTime)))
+}
+
+// fetchItem2XFromCache fills item2XMap with cached property values and
+// returns the item ids missed in cache
+func fetchItem2XFromCache(c cache.Cache, itemIds []string, item2XMap map[string]string) (missedIds []string) {
+	if c == nil {
+		return itemIds
+	}
+	for _, id := range itemIds {
+		if cacheValue, ok := c.GetIfPresent(id); ok {
+			if xVal, ok := cacheValue.(string); ok {
+				// empty string is the negative cache value, means the item has no property value
+				if xVal != "" {
+					item2XMap[id] = xVal
+				}
+				continue
+			}
+		}
+		missedIds = append(missedIds, id)
+	}
+	return
+}
+
+// putItem2XToCache puts fetched property values into cache, item ids not in
+// fetchedMap are cached as empty string (negative cache)
+func putItem2XToCache(c cache.Cache, itemIds []string, fetchedMap map[string]string) {
+	if c == nil {
+		return
+	}
+	for _, id := range itemIds {
+		c.Put(id, fetchedMap[id])
+	}
+}

--- a/module/item2x_featurestore_dao.go
+++ b/module/item2x_featurestore_dao.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/alibaba/pairec/v2/context"
 	"github.com/alibaba/pairec/v2/log"
@@ -72,7 +73,7 @@ func (d *Item2XFeatureStoreDao) ListItem2X(itemIds []string, context *context.Re
 	for _, featureMap := range features {
 		itemId := utils.ToString(featureMap[featureEntity.FeatureEntityJoinid], "")
 		xVal := utils.ToString(featureMap[d.xKey], "")
-		if itemId != "" && xVal != "" && xVal != "null" {
+		if itemId != "" && xVal != "" && !strings.EqualFold(xVal, "null") {
 			item2XMap[itemId] = xVal
 		}
 	}

--- a/module/item2x_featurestore_dao.go
+++ b/module/item2x_featurestore_dao.go
@@ -1,0 +1,83 @@
+package module
+
+import (
+	"fmt"
+
+	"github.com/alibaba/pairec/v2/context"
+	"github.com/alibaba/pairec/v2/log"
+	"github.com/alibaba/pairec/v2/persist/fs"
+	"github.com/alibaba/pairec/v2/recconf"
+	"github.com/alibaba/pairec/v2/utils"
+	"github.com/goburrow/cache"
+)
+
+// Item2XFeatureStoreDao gets item property(x) values from a featurestore item attribute feature view.
+type Item2XFeatureStoreDao struct {
+	fsClient    *fs.FSClient
+	item2XTable string
+	xKey        string
+	cache       cache.Cache
+}
+
+func NewItem2XFeatureStoreDao(config recconf.Item2XConfig) *Item2XFeatureStoreDao {
+	dao := &Item2XFeatureStoreDao{
+		item2XTable: config.Item2XTable,
+		xKey:        config.XKey,
+		cache:       newItem2XCache(config),
+	}
+
+	fsclient, err := fs.GetFeatureStoreClient(config.FeatureStoreName)
+	if err != nil {
+		panic(fmt.Sprintf("get featurestore client error, name:%s, error:%v", config.FeatureStoreName, err))
+	}
+	dao.fsClient = fsclient
+
+	return dao
+}
+
+func (d *Item2XFeatureStoreDao) ListItem2X(itemIds []string, context *context.RecommendContext) map[string]string {
+	item2XMap := make(map[string]string, len(itemIds))
+	if len(itemIds) == 0 {
+		return item2XMap
+	}
+
+	missedIds := fetchItem2XFromCache(d.cache, itemIds, item2XMap)
+	if len(missedIds) == 0 {
+		return item2XMap
+	}
+
+	featureView := d.fsClient.GetProject().GetFeatureView(d.item2XTable)
+	if featureView == nil {
+		log.Error(fmt.Sprintf("requestId=%s\tmodule=Item2XFeatureStoreDao\terror=featureView not found, featureview:%s", context.RecommendId, d.item2XTable))
+		return item2XMap
+	}
+
+	ids := make([]interface{}, 0, len(missedIds))
+	for _, id := range missedIds {
+		ids = append(ids, id)
+	}
+
+	features, err := featureView.GetOnlineFeatures(ids, []string{d.xKey}, nil)
+	if err != nil {
+		log.Error(fmt.Sprintf("requestId=%s\tmodule=Item2XFeatureStoreDao\terror=%v", context.RecommendId, err))
+		return item2XMap
+	}
+
+	featureEntity := d.fsClient.GetProject().GetFeatureEntity(featureView.GetFeatureEntityName())
+	if featureEntity == nil {
+		log.Error(fmt.Sprintf("requestId=%s\tmodule=Item2XFeatureStoreDao\terror=featureEntity not found, featureEntity:%s", context.RecommendId, featureView.GetFeatureEntityName()))
+		return item2XMap
+	}
+
+	for _, featureMap := range features {
+		itemId := utils.ToString(featureMap[featureEntity.FeatureEntityJoinid], "")
+		xVal := utils.ToString(featureMap[d.xKey], "")
+		if itemId != "" && xVal != "" && xVal != "null" {
+			item2XMap[itemId] = xVal
+		}
+	}
+
+	putItem2XToCache(d.cache, missedIds, item2XMap)
+
+	return item2XMap
+}

--- a/module/item2x_hologres_dao.go
+++ b/module/item2x_hologres_dao.go
@@ -1,0 +1,125 @@
+package module
+
+import (
+	gocontext "context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/alibaba/pairec/v2/context"
+	"github.com/alibaba/pairec/v2/log"
+	"github.com/alibaba/pairec/v2/persist/holo"
+	"github.com/alibaba/pairec/v2/recconf"
+	"github.com/goburrow/cache"
+	"github.com/huandu/go-sqlbuilder"
+)
+
+// Item2XHologresDao gets item property(x) values from a hologres item attribute table.
+type Item2XHologresDao struct {
+	db            *sql.DB
+	item2XTable   string
+	xKey          string
+	itemKeyField  string
+	cache         cache.Cache
+	mu            sync.RWMutex
+	item2XStmtMap map[int]*sql.Stmt
+}
+
+func NewItem2XHologresDao(config recconf.Item2XConfig) *Item2XHologresDao {
+	dao := &Item2XHologresDao{
+		item2XTable:   config.Item2XTable,
+		xKey:          config.XKey,
+		itemKeyField:  "item_id",
+		cache:         newItem2XCache(config),
+		item2XStmtMap: make(map[int]*sql.Stmt, 0),
+	}
+	if config.ItemKeyField != "" {
+		dao.itemKeyField = config.ItemKeyField
+	}
+
+	hologres, err := holo.GetPostgres(config.HologresName)
+	if err != nil {
+		panic(fmt.Sprintf("get hologres error, name:%s, error:%v", config.HologresName, err))
+	}
+	dao.db = hologres.DB
+
+	return dao
+}
+
+func (d *Item2XHologresDao) getItem2XStmt(key int) *sql.Stmt {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.item2XStmtMap[key]
+}
+
+func (d *Item2XHologresDao) ListItem2X(itemIds []string, context *context.RecommendContext) map[string]string {
+	item2XMap := make(map[string]string, len(itemIds))
+	if len(itemIds) == 0 {
+		return item2XMap
+	}
+
+	missedIds := fetchItem2XFromCache(d.cache, itemIds, item2XMap)
+	if len(missedIds) == 0 {
+		return item2XMap
+	}
+
+	ids := make([]interface{}, 0, len(missedIds))
+	for _, id := range missedIds {
+		ids = append(ids, id)
+	}
+
+	sb := sqlbuilder.PostgreSQL.NewSelectBuilder()
+	sb.Select(d.itemKeyField, d.xKey).
+		From(d.item2XTable).
+		Where(
+			sb.In(d.itemKeyField, ids...),
+		)
+	sqlStr, args := sb.Build()
+
+	stmtkey := len(ids)
+	stmt := d.getItem2XStmt(stmtkey)
+	if stmt == nil {
+		d.mu.Lock()
+		stmt = d.item2XStmtMap[stmtkey]
+		if stmt == nil {
+			stmt2, err := d.db.Prepare(sqlStr)
+			if err != nil {
+				log.Error(fmt.Sprintf("requestId=%s\tmodule=Item2XHologresDao\terror=hologres error(%v)", context.RecommendId, err))
+				d.mu.Unlock()
+				return item2XMap
+			}
+			d.item2XStmtMap[stmtkey] = stmt2
+			stmt = stmt2
+			d.mu.Unlock()
+		} else {
+			d.mu.Unlock()
+		}
+	}
+
+	ctx, cancel := gocontext.WithTimeout(gocontext.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	rows, err := stmt.QueryContext(ctx, args...)
+	if err != nil {
+		log.Error(fmt.Sprintf("requestId=%s\tmodule=Item2XHologresDao\tsql=%s\terror=%v", context.RecommendId, sqlStr, err))
+		return item2XMap
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var itemId string
+		var xVal sql.NullString
+		if err := rows.Scan(&itemId, &xVal); err != nil {
+			log.Error(fmt.Sprintf("requestId=%s\tmodule=Item2XHologresDao\terror=%v", context.RecommendId, err))
+			continue
+		}
+		if xVal.Valid && xVal.String != "" {
+			item2XMap[itemId] = xVal.String
+		}
+	}
+
+	putItem2XToCache(d.cache, missedIds, item2XMap)
+
+	return item2XMap
+}

--- a/module/realtime_user2item_be_dao.go
+++ b/module/realtime_user2item_be_dao.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"github.com/Knetic/govaluate"
-	be "github.com/aliyun/aliyun-be-go-sdk"
 	"github.com/alibaba/pairec/v2/context"
 	"github.com/alibaba/pairec/v2/datasource/beengine"
 	"github.com/alibaba/pairec/v2/log"
 	"github.com/alibaba/pairec/v2/recconf"
 	"github.com/alibaba/pairec/v2/utils"
+	be "github.com/aliyun/aliyun-be-go-sdk"
 )
 
 type RealtimeUser2ItemBeDao struct {
@@ -138,6 +138,10 @@ func (d *RealtimeUser2ItemBeDao) GetTriggerInfos(user *User, context *context.Re
 		}
 		if trigger.ItemId != "" && trigger.event != "" {
 			trigger.propertyFieldValues = propertyFieldValues
+		}
+		// only use behaviors within the recent time window if configured
+		if isTriggerOutOfTimeWindow(trigger.timestamp, currentTime.Unix(), d.triggerTimeWindow) {
+			continue
 		}
 		if t, exist := d.eventPlayTimeMap[trigger.event]; exist {
 			if trigger.playTime <= t {

--- a/module/realtime_user2item_dao.go
+++ b/module/realtime_user2item_dao.go
@@ -73,20 +73,23 @@ type RealtimeUser2ItemBaseDao struct {
 	eventWeightMap   map[string]float64
 	mergeMode        string
 	cache            cache.Cache
+	// triggerTimeWindow only uses behaviors within the recent time window (seconds), 0 means no limit
+	triggerTimeWindow int64
 }
 
 func NewRealtimeUser2ItemBaseDao(config *recconf.RecallConfig) *RealtimeUser2ItemBaseDao {
 	dao := &RealtimeUser2ItemBaseDao{
-		recallName:       config.Name,
-		recallCount:      config.RecallCount,
-		diversityRules:   config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.DiversityRules,
-		propertyFields:   config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.PropertyFields,
-		propertyFieldMap: make(map[string]int, len(config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.PropertyFields)),
-		triggerCount:     config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.TriggerCount,
-		limit:            config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.Limit,
-		eventPlayTimeMap: make(map[string]float64),
-		eventWeightMap:   make(map[string]float64),
-		mergeMode:        config.RealTimeUser2ItemDaoConf.MergeMode,
+		recallName:        config.Name,
+		recallCount:       config.RecallCount,
+		diversityRules:    config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.DiversityRules,
+		propertyFields:    config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.PropertyFields,
+		propertyFieldMap:  make(map[string]int, len(config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.PropertyFields)),
+		triggerCount:      config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.TriggerCount,
+		limit:             config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.Limit,
+		eventPlayTimeMap:  make(map[string]float64),
+		eventWeightMap:    make(map[string]float64),
+		mergeMode:         config.RealTimeUser2ItemDaoConf.MergeMode,
+		triggerTimeWindow: config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.TriggerTimeWindow,
 	}
 
 	if dao.triggerCount == 0 {

--- a/module/realtime_user2item_featurestore_dao.go
+++ b/module/realtime_user2item_featurestore_dao.go
@@ -32,6 +32,7 @@ type RealtimeUser2ItemFeatureStoreDao struct {
 	events                    []any
 	similarItemIdField        string
 	additionUid               string
+	triggerTimeWindow         int64
 }
 
 func NewRealtimeUser2ItemFeatureStoreDao(config recconf.RecallConfig) *RealtimeUser2ItemFeatureStoreDao {
@@ -48,6 +49,7 @@ func NewRealtimeUser2ItemFeatureStoreDao(config recconf.RecallConfig) *RealtimeU
 		timestampFieldName:       "timestamp",
 		similarItemIdField:       "similar_item_ids",
 		additionUid:              config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.AdditionUid,
+		triggerTimeWindow:        config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.TriggerTimeWindow,
 	}
 	if config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.NoUsePlayTimeField {
 		dao.hasPlayTimeField = false
@@ -347,6 +349,10 @@ func (d *RealtimeUser2ItemFeatureStoreDao) GetTriggerInfos(user *User, context *
 		trigger.ItemId = utils.ToString(seqData[d.itemIdFieldName], "")
 		trigger.event = utils.ToString(seqData[d.eventFieldName], "")
 		trigger.timestamp = utils.ToInt64(seqData[d.timestampFieldName], 0)
+		// only use behaviors within the recent time window if configured
+		if isTriggerOutOfTimeWindow(trigger.timestamp, currentTime.Unix(), d.triggerTimeWindow) {
+			continue
+		}
 		if d.hasPlayTimeField {
 			trigger.playTime = utils.ToFloat(seqData[d.playtimeFieldName], 0)
 		}

--- a/module/realtime_user2item_featurestore_dao.go
+++ b/module/realtime_user2item_featurestore_dao.go
@@ -32,7 +32,6 @@ type RealtimeUser2ItemFeatureStoreDao struct {
 	events                    []any
 	similarItemIdField        string
 	additionUid               string
-	triggerTimeWindow         int64
 }
 
 func NewRealtimeUser2ItemFeatureStoreDao(config recconf.RecallConfig) *RealtimeUser2ItemFeatureStoreDao {
@@ -49,7 +48,6 @@ func NewRealtimeUser2ItemFeatureStoreDao(config recconf.RecallConfig) *RealtimeU
 		timestampFieldName:       "timestamp",
 		similarItemIdField:       "similar_item_ids",
 		additionUid:              config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.AdditionUid,
-		triggerTimeWindow:        config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.TriggerTimeWindow,
 	}
 	if config.RealTimeUser2ItemDaoConf.UserTriggerDaoConf.NoUsePlayTimeField {
 		dao.hasPlayTimeField = false

--- a/module/realtime_user2item_hologres_dao.go
+++ b/module/realtime_user2item_hologres_dao.go
@@ -272,6 +272,10 @@ func (d *RealtimeUser2ItemHologresDao) GetTriggerInfos(user *User, context *cont
 			}
 		}
 		if err := rows.Scan(dst...); err == nil {
+			// only use behaviors within the recent time window if configured
+			if isTriggerOutOfTimeWindow(trigger.timestamp, currentTime.Unix(), d.triggerTimeWindow) {
+				continue
+			}
 			if t, exist := d.eventPlayTimeMap[trigger.event]; exist {
 				if trigger.playTime <= t {
 					continue

--- a/module/realtime_user2item_u2i2x2i_hologres_dao.go
+++ b/module/realtime_user2item_u2i2x2i_hologres_dao.go
@@ -331,6 +331,10 @@ func (d *RealtimeUser2Item2X2ItemHologresDao) GetTriggerInfos(user *User, contex
 			}
 		}
 		if err := rows.Scan(dst...); err == nil {
+			// only use behaviors within the recent time window if configured
+			if isTriggerOutOfTimeWindow(trigger.timestamp, currentTime.Unix(), d.triggerTimeWindow) {
+				continue
+			}
 			if t, exist := d.eventPlayTimeMap[trigger.event]; exist {
 				if trigger.playTime <= t {
 					continue

--- a/module/trigger_info.go
+++ b/module/trigger_info.go
@@ -2,6 +2,8 @@ package module
 
 import (
 	"database/sql"
+	gosort "sort"
+	"strings"
 )
 
 type TriggerInfo struct {
@@ -42,4 +44,54 @@ func (us TriggerInfoSlice) Swap(i, j int) {
 	tmp := us[i]
 	us[i] = us[j]
 	us[j] = tmp
+}
+
+// isTriggerOutOfTimeWindow reports whether the behavior timestamp is out of the recent time window.
+// timeWindow <= 0 means no time window filter.
+func isTriggerOutOfTimeWindow(timestamp, nowUnix, timeWindow int64) bool {
+	return timeWindow > 0 && timestamp < nowUnix-timeWindow
+}
+
+// aggregatePropertyWeights splits the property value by delimiter and accumulates
+// the trigger weight into each property value, then returns synthesized TriggerInfos
+// (ItemId is the property value) sorted by weight in descending order.
+func aggregatePropertyWeights(triggerInfos []*TriggerInfo, valueFunc func(*TriggerInfo) string, delimiter string) (ret []*TriggerInfo) {
+	xWeightMap := make(map[string]float64, len(triggerInfos))
+	for _, info := range triggerInfos {
+		xVal := valueFunc(info)
+		if xVal == "" || xVal == "null" {
+			continue
+		}
+		if delimiter != "" {
+			for _, v := range strings.Split(xVal, delimiter) {
+				if v != "" {
+					xWeightMap[v] += info.Weight
+				}
+			}
+		} else {
+			xWeightMap[xVal] += info.Weight
+		}
+	}
+
+	for xVal, weight := range xWeightMap {
+		ret = append(ret, &TriggerInfo{ItemId: xVal, Weight: weight})
+	}
+	gosort.Sort(gosort.Reverse(TriggerInfoSlice(ret)))
+	return
+}
+
+// AggregateTriggerPropertyWeights aggregates item trigger weights into property(x) level triggers,
+// the property value comes from the trigger property fields (mode 1).
+func AggregateTriggerPropertyWeights(triggerInfos []*TriggerInfo, xKey string, propertyFieldMap map[string]int, delimiter string) []*TriggerInfo {
+	return aggregatePropertyWeights(triggerInfos, func(info *TriggerInfo) string {
+		return info.StringProperty(xKey, propertyFieldMap)
+	}, delimiter)
+}
+
+// AggregateItem2XWeights aggregates item trigger weights into property(x) level triggers,
+// the property value comes from item2XMap joined by item id (mode 2).
+func AggregateItem2XWeights(triggerInfos []*TriggerInfo, item2XMap map[string]string, delimiter string) []*TriggerInfo {
+	return aggregatePropertyWeights(triggerInfos, func(info *TriggerInfo) string {
+		return item2XMap[info.ItemId]
+	}, delimiter)
 }

--- a/module/trigger_info.go
+++ b/module/trigger_info.go
@@ -47,9 +47,14 @@ func (us TriggerInfoSlice) Swap(i, j int) {
 }
 
 // isTriggerOutOfTimeWindow reports whether the behavior timestamp is out of the recent time window.
-// timeWindow <= 0 means no time window filter.
+// timeWindow <= 0 means no time window filter. timestamp <= 0 means the behavior has no valid
+// time info (field missing or unparsable), keep it instead of treating it as expired,
+// otherwise a misconfigured timestamp field would silently clear the whole recall path.
 func isTriggerOutOfTimeWindow(timestamp, nowUnix, timeWindow int64) bool {
-	return timeWindow > 0 && timestamp < nowUnix-timeWindow
+	if timeWindow <= 0 || timestamp <= 0 {
+		return false
+	}
+	return timestamp < nowUnix-timeWindow
 }
 
 // aggregatePropertyWeights splits the property value by delimiter and accumulates

--- a/module/trigger_info.go
+++ b/module/trigger_info.go
@@ -59,7 +59,7 @@ func aggregatePropertyWeights(triggerInfos []*TriggerInfo, valueFunc func(*Trigg
 	xWeightMap := make(map[string]float64, len(triggerInfos))
 	for _, info := range triggerInfos {
 		xVal := valueFunc(info)
-		if xVal == "" || xVal == "null" {
+		if xVal == "" || strings.EqualFold(xVal, "null") {
 			continue
 		}
 		if delimiter != "" {

--- a/module/trigger_info_test.go
+++ b/module/trigger_info_test.go
@@ -1,0 +1,156 @@
+package module
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/alibaba/pairec/v2/recconf"
+)
+
+func newTestTriggerInfo(itemId string, weight float64, propertyValues ...string) *TriggerInfo {
+	info := &TriggerInfo{
+		ItemId: itemId,
+		Weight: weight,
+	}
+	for _, v := range propertyValues {
+		info.propertyFieldValues = append(info.propertyFieldValues, sql.NullString{String: v, Valid: true})
+	}
+	return info
+}
+
+func TestAggregateTriggerPropertyWeights(t *testing.T) {
+	propertyFieldMap := map[string]int{"tags": 0, "category": 1}
+
+	t.Run("multi value split and weight sum", func(t *testing.T) {
+		triggerInfos := []*TriggerInfo{
+			newTestTriggerInfo("item1", 3, "tag1|tag2", "c1"),
+			newTestTriggerInfo("item2", 2, "tag2|tag3", "c2"),
+			newTestTriggerInfo("item3", 1, "tag3", "c3"),
+		}
+		ret := AggregateTriggerPropertyWeights(triggerInfos, "tags", propertyFieldMap, "|")
+		if len(ret) != 3 {
+			t.Fatalf("expect 3 property triggers, got %d", len(ret))
+		}
+		weights := make(map[string]float64, len(ret))
+		for _, info := range ret {
+			weights[info.ItemId] = info.Weight
+		}
+		if weights["tag1"] != 3 || weights["tag2"] != 5 || weights["tag3"] != 3 {
+			t.Fatalf("unexpected weights: %v", weights)
+		}
+		// sorted by weight in descending order
+		if ret[0].ItemId != "tag2" {
+			t.Fatalf("expect tag2 first, got %s", ret[0].ItemId)
+		}
+	})
+
+	t.Run("single value without delimiter", func(t *testing.T) {
+		triggerInfos := []*TriggerInfo{
+			newTestTriggerInfo("item1", 2, "tag1", "c1"),
+			newTestTriggerInfo("item2", 1, "tag1", "c1"),
+		}
+		ret := AggregateTriggerPropertyWeights(triggerInfos, "category", propertyFieldMap, "")
+		if len(ret) != 1 || ret[0].ItemId != "c1" || ret[0].Weight != 3 {
+			t.Fatalf("unexpected result: %+v", ret)
+		}
+	})
+
+	t.Run("empty and null values are skipped", func(t *testing.T) {
+		triggerInfos := []*TriggerInfo{
+			newTestTriggerInfo("item1", 2, "", "c1"),
+			newTestTriggerInfo("item2", 1, "null", "c2"),
+			newTestTriggerInfo("item3", 1, "tag1|", "c3"),
+		}
+		ret := AggregateTriggerPropertyWeights(triggerInfos, "tags", propertyFieldMap, "|")
+		if len(ret) != 1 || ret[0].ItemId != "tag1" || ret[0].Weight != 1 {
+			t.Fatalf("unexpected result: %+v", ret)
+		}
+	})
+
+	t.Run("xKey not in propertyFieldMap returns empty", func(t *testing.T) {
+		triggerInfos := []*TriggerInfo{
+			newTestTriggerInfo("item1", 2, "tag1", "c1"),
+		}
+		ret := AggregateTriggerPropertyWeights(triggerInfos, "not_exist", propertyFieldMap, "|")
+		if len(ret) != 0 {
+			t.Fatalf("expect empty result, got %+v", ret)
+		}
+	})
+}
+
+func TestAggregateItem2XWeights(t *testing.T) {
+	triggerInfos := []*TriggerInfo{
+		{ItemId: "item1", Weight: 3},
+		{ItemId: "item2", Weight: 2},
+		{ItemId: "item3", Weight: 1}, // not in item2XMap, skipped
+	}
+	item2XMap := map[string]string{
+		"item1": "tag1,tag2",
+		"item2": "tag2",
+	}
+	ret := AggregateItem2XWeights(triggerInfos, item2XMap, ",")
+	if len(ret) != 2 {
+		t.Fatalf("expect 2 property triggers, got %d", len(ret))
+	}
+	if ret[0].ItemId != "tag2" || ret[0].Weight != 5 {
+		t.Fatalf("expect tag2:5 first, got %s:%f", ret[0].ItemId, ret[0].Weight)
+	}
+	if ret[1].ItemId != "tag1" || ret[1].Weight != 3 {
+		t.Fatalf("expect tag1:3 second, got %s:%f", ret[1].ItemId, ret[1].Weight)
+	}
+}
+
+func TestIsTriggerOutOfTimeWindow(t *testing.T) {
+	now := int64(1700000000)
+
+	// timeWindow not configured, no filter
+	if isTriggerOutOfTimeWindow(now-999999, now, 0) {
+		t.Fatal("expect no filter when timeWindow is 0")
+	}
+	// behavior within the time window is kept
+	if isTriggerOutOfTimeWindow(now-100, now, 3600) {
+		t.Fatal("expect behavior within time window to be kept")
+	}
+	// behavior at the window boundary is kept
+	if isTriggerOutOfTimeWindow(now-3600, now, 3600) {
+		t.Fatal("expect behavior at window boundary to be kept")
+	}
+	// behavior out of the time window is filtered
+	if !isTriggerOutOfTimeWindow(now-3601, now, 3600) {
+		t.Fatal("expect behavior out of time window to be filtered")
+	}
+}
+
+func TestItem2XCache(t *testing.T) {
+	t.Run("cache disabled when CacheSize not configured", func(t *testing.T) {
+		if c := newItem2XCache(recconf.Item2XConfig{}); c != nil {
+			t.Fatal("expect nil cache when CacheSize is 0")
+		}
+		item2XMap := make(map[string]string)
+		missedIds := fetchItem2XFromCache(nil, []string{"item1", "item2"}, item2XMap)
+		if len(missedIds) != 2 {
+			t.Fatalf("expect all ids missed without cache, got %v", missedIds)
+		}
+	})
+
+	t.Run("cache hit and negative cache", func(t *testing.T) {
+		c := newItem2XCache(recconf.Item2XConfig{CacheSize: 100, CacheTime: 60})
+		if c == nil {
+			t.Fatal("expect cache created")
+		}
+		// item1 has property value, item2 has no data (negative cache)
+		putItem2XToCache(c, []string{"item1", "item2"}, map[string]string{"item1": "tag1|tag2"})
+
+		item2XMap := make(map[string]string)
+		missedIds := fetchItem2XFromCache(c, []string{"item1", "item2", "item3"}, item2XMap)
+		if len(missedIds) != 1 || missedIds[0] != "item3" {
+			t.Fatalf("expect only item3 missed, got %v", missedIds)
+		}
+		if item2XMap["item1"] != "tag1|tag2" {
+			t.Fatalf("expect item1 hit cache, got %v", item2XMap)
+		}
+		if _, exist := item2XMap["item2"]; exist {
+			t.Fatal("expect item2 negative cached and not in result")
+		}
+	})
+}

--- a/module/trigger_info_test.go
+++ b/module/trigger_info_test.go
@@ -59,7 +59,9 @@ func TestAggregateTriggerPropertyWeights(t *testing.T) {
 		triggerInfos := []*TriggerInfo{
 			newTestTriggerInfo("item1", 2, "", "c1"),
 			newTestTriggerInfo("item2", 1, "null", "c2"),
-			newTestTriggerInfo("item3", 1, "tag1|", "c3"),
+			newTestTriggerInfo("item3", 1, "NULL", "c3"),
+			newTestTriggerInfo("item4", 1, "Null", "c4"),
+			newTestTriggerInfo("item5", 1, "tag1|", "c5"),
 		}
 		ret := AggregateTriggerPropertyWeights(triggerInfos, "tags", propertyFieldMap, "|")
 		if len(ret) != 1 || ret[0].ItemId != "tag1" || ret[0].Weight != 1 {

--- a/module/trigger_info_test.go
+++ b/module/trigger_info_test.go
@@ -121,6 +121,14 @@ func TestIsTriggerOutOfTimeWindow(t *testing.T) {
 	if !isTriggerOutOfTimeWindow(now-3601, now, 3600) {
 		t.Fatal("expect behavior out of time window to be filtered")
 	}
+	// timestamp 0 means no valid time info, keep it even when timeWindow is configured
+	if isTriggerOutOfTimeWindow(0, now, 3600) {
+		t.Fatal("expect behavior with zero timestamp to be kept")
+	}
+	// negative timestamp is also treated as no valid time info
+	if isTriggerOutOfTimeWindow(-1, now, 3600) {
+		t.Fatal("expect behavior with negative timestamp to be kept")
+	}
 }
 
 func TestItem2XCache(t *testing.T) {

--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -444,7 +444,25 @@ type RecallEngineParam struct {
 	DiversityParam  string
 	CustomParams    map[string]interface{}
 	TriggerLimit    int
-	Timeout         int // per-way recall timeout in milliseconds, 0 means no per-way timeout
+	Timeout         int          // per-way recall timeout in milliseconds, 0 means no per-way timeout
+	Item2XConf      Item2XConfig // aggregate item triggers to item property(x) triggers, empty XKey means disabled
+}
+
+// Item2XConfig aggregates item level trigger weights into item property(x) level triggers.
+// XKey is the property field name, non-empty XKey enables the aggregation.
+// When Item2XTable is empty, the property value comes from UserTriggerDaoConf.PropertyFields (mode 1);
+// otherwise the property value is joined from Item2XTable by item id (mode 2).
+type Item2XConfig struct {
+	XKey             string // property field name, non-empty means enabled; must be in PropertyFields when Item2XTable is empty
+	XDelimiter       string // delimiter to split multi-value property, empty means single value
+	XCount           int    // max number of property triggers after aggregation, 0 means no limit
+	AdapterType      string // hologres or featurestore, only used when Item2XTable is not empty
+	HologresName     string // hologres datasource name
+	FeatureStoreName string // featurestore datasource name
+	Item2XTable      string // hologres table name or featurestore feature view name, empty means mode 1
+	ItemKeyField     string // item id field name of Item2XTable, only for hologres, default is item_id
+	CacheSize        int    // local cache size of itemId => property value, 0 means cache disabled
+	CacheTime        int    // cache expire time in seconds, default is 3600
 }
 type RecallNameMappingConfig struct {
 	Format string
@@ -559,6 +577,8 @@ type UserTriggerDaoConfig struct {
 	PlayTimeFieldName  string
 
 	AdditionUid string
+
+	TriggerTimeWindow int64 // only use behaviors within recent N seconds, 0 means no time window filter
 }
 type TriggerDiversityRuleConfig struct {
 	Dimensions []string

--- a/service/recall/recallenginerecall/trigger_key.go
+++ b/service/recall/recallenginerecall/trigger_key.go
@@ -30,7 +30,7 @@ func NewTriggerKey(recallParam *recconf.RecallEngineParam, client *recallengine.
 		trigger := NewItemTrigger()
 		return trigger
 	case "u2i_realtime":
-		trigger := NewU2IRealtimeTrigger(&recallParam.UserTriggerDaoConf, &recallParam.UserTriggerRulesConf)
+		trigger := NewU2IRealtimeTrigger(&recallParam.UserTriggerDaoConf, &recallParam.UserTriggerRulesConf, &recallParam.Item2XConf)
 		return trigger
 	case "user_realtime_embedding":
 		trigger := NewUserRealtimeEmbeddingTrigger(&recallParam.UserRealtimeEmbeddingTrigger)

--- a/service/recall/recallenginerecall/u2i_realtime_trigger.go
+++ b/service/recall/recallenginerecall/u2i_realtime_trigger.go
@@ -1,6 +1,8 @@
 package recallenginerecall
 
 import (
+	"fmt"
+
 	"github.com/alibaba/pairec/v2/context"
 	"github.com/alibaba/pairec/v2/module"
 	"github.com/alibaba/pairec/v2/recconf"
@@ -9,9 +11,16 @@ import (
 type U2IRealtimeTrigger struct {
 	*U2IBaseTrigger
 	user2ItemDao module.RealTimeUser2ItemDao
+
+	// item property(x) aggregation, enabled when xKey is not empty
+	xKey             string
+	xDelimiter       string
+	xCount           int
+	item2XDao        module.Item2XDao // mode 2, joins property values by item ids
+	propertyFieldMap map[string]int   // mode 1, index of xKey in PropertyFields
 }
 
-func NewU2IRealtimeTrigger(config *recconf.UserTriggerDaoConfig, rulesConfig *recconf.UserTriggerRulesConfig) *U2IRealtimeTrigger {
+func NewU2IRealtimeTrigger(config *recconf.UserTriggerDaoConfig, rulesConfig *recconf.UserTriggerRulesConfig, item2XConf *recconf.Item2XConfig) *U2IRealtimeTrigger {
 	conf := recconf.RecallConfig{
 		RealTimeUser2ItemDaoConf: recconf.RealTimeUser2ItemDaoConfig{
 			UserTriggerDaoConf: *config,
@@ -22,10 +31,50 @@ func NewU2IRealtimeTrigger(config *recconf.UserTriggerDaoConfig, rulesConfig *re
 		U2IBaseTrigger: NewU2IBaseTrigger(rulesConfig),
 	}
 
+	if item2XConf != nil && item2XConf.XKey != "" {
+		trigger.xKey = item2XConf.XKey
+		trigger.xDelimiter = item2XConf.XDelimiter
+		trigger.xCount = item2XConf.XCount
+		if item2XConf.Item2XTable != "" {
+			// mode 2: join property values from the item attribute table
+			trigger.item2XDao = module.NewItem2XDao(*item2XConf)
+		} else {
+			// mode 1: property values come from the behavior table PropertyFields
+			trigger.propertyFieldMap = make(map[string]int, len(config.PropertyFields))
+			for i, field := range config.PropertyFields {
+				trigger.propertyFieldMap[field] = i
+			}
+			if _, exist := trigger.propertyFieldMap[trigger.xKey]; !exist {
+				panic(fmt.Sprintf("Item2XConf.XKey(%s) not found in UserTriggerDaoConf.PropertyFields", trigger.xKey))
+			}
+		}
+	}
+
 	return trigger
 }
 func (t *U2IRealtimeTrigger) GetTriggerKey(user *module.User, context *context.RecommendContext) *TriggerResult {
 	triggerInfos := t.user2ItemDao.GetTriggerInfos(user, context)
 
-	return t.CreateTriggerResult(triggerInfos)
+	if t.xKey == "" {
+		return t.CreateTriggerResult(triggerInfos)
+	}
+
+	// aggregate item triggers to property(x) triggers
+	var xTriggerInfos []*module.TriggerInfo
+	if t.item2XDao != nil {
+		itemIds := make([]string, 0, len(triggerInfos))
+		for _, info := range triggerInfos {
+			itemIds = append(itemIds, info.ItemId)
+		}
+		item2XMap := t.item2XDao.ListItem2X(itemIds, context)
+		xTriggerInfos = module.AggregateItem2XWeights(triggerInfos, item2XMap, t.xDelimiter)
+	} else {
+		xTriggerInfos = module.AggregateTriggerPropertyWeights(triggerInfos, t.xKey, t.propertyFieldMap, t.xDelimiter)
+	}
+
+	if t.xCount > 0 && len(xTriggerInfos) > t.xCount {
+		xTriggerInfos = xTriggerInfos[:t.xCount]
+	}
+
+	return t.CreateTriggerResult(xTriggerInfos)
 }


### PR DESCRIPTION
## Summary

Extend the existing `u2i_realtime` TriggerType of recall engine recall with two capabilities (both are opt-in by config, behavior is unchanged when not configured):

### 1. Item property aggregation recall (`Item2XConf`)

User behavior sequences may carry multi-value properties (e.g. tags). Since FeatureStore behavior sequences cannot store array type, they are stored as delimiter-joined strings like `"tag1|tag2|tag3"`. This PR supports aggregating item level trigger weights into property(x) level triggers (`propertyValue:weight`), so the recall engine can recall through x2i (e.g. tag2i) tables.

Two property source modes:
- **Mode 1**: property fields already exist in the behavior table, read from `UserTriggerDaoConf.PropertyFields` with zero extra query
- **Mode 2**: join property values from an item attribute table (`Item2XTable`, Hologres / FeatureStore) by item id, with optional local cache (`CacheSize` / `CacheTime`, including negative cache)

```json
{
  "TriggerType": "u2i_realtime",
  "UserTriggerDaoConf": { "AdapterType": "featurestore", "PropertyFields": ["tags"], "TriggerTimeWindow": 86400 },
  "UserTriggerRulesConf": { "TriggerCounts": [30, 20, 10] },
  "Item2XConf": { "XKey": "tags", "XDelimiter": "|", "XCount": 10 }
}
```

### 2. Behavior sequence time window (`UserTriggerDaoConf.TriggerTimeWindow`)

Only use behaviors within recent N seconds for trigger computation, configured independently per recall param. Filtering is done in-memory in pairec since the FS SDK behavior query has no time parameter.

## Key Changes

- `recconf/recconf.go`: new `Item2XConfig` struct, `RecallEngineParam.Item2XConf`, `UserTriggerDaoConfig.TriggerTimeWindow`
- `module/item2x_dao.go` / `item2x_hologres_dao.go` / `item2x_featurestore_dao.go`: `Item2XDao` interface, factory and backends with local cache support
- `module/trigger_info.go`: property weight aggregation functions (`AggregateTriggerPropertyWeights` / `AggregateItem2XWeights`) and time window helper
- `module/realtime_user2item_featurestore_dao.go`: time window filter in `GetTriggerInfos`
- `service/recall/recallenginerecall/u2i_realtime_trigger.go`: two property aggregation modes wired into `GetTriggerKey`
- `module/trigger_info_test.go`: unit tests for aggregation, time window and cache helpers

## Test

- `go build ./...` passed
- `go test ./module/...` passed (new tests cover multi-value split, weight sum, empty/null skip, descending order, time window boundary, cache hit / negative cache)
