### PR TITLE
feat: add per-recall duration histogram and empty-result counter metrics

### DIFF
--- a/service/metrics/metrics.go
+++ b/service/metrics/metrics.go
@@ -15,8 +15,10 @@ var (
 	RecTotal              *prometheus.CounterVec
 	RecallCount           *prometheus.CounterVec
 	RecallCountTotal      *prometheus.CounterVec
+	RecallEmptyTotal      *prometheus.CounterVec
 	RecallItemsPercentage *prometheus.GaugeVec
 	RecallDurSecs         *prometheus.HistogramVec
+	RecallDurByName       *prometheus.HistogramVec
 	FilterDurSecs         *prometheus.HistogramVec
 	GeneralRankDurSecs    *prometheus.HistogramVec
 	LoadFeatureDurSecs    *prometheus.HistogramVec
@@ -43,9 +45,11 @@ func Load(conf *recconf.RecommendConfig) {
 			SizeNotEnoughTotal,
 			RecallCount,
 			RecallCountTotal,
+			RecallEmptyTotal,
 			RecallItemsPercentage,
 			RecDurSecs,
 			RecallDurSecs,
+			RecallDurByName,
 			FilterDurSecs,
 			GeneralRankDurSecs,
 			LoadFeatureDurSecs,
@@ -109,6 +113,15 @@ func initMetrics(conf *recconf.RecommendConfig) {
 		"scene",
 	})
 
+	RecallEmptyTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Subsystem: subsystem,
+		Name:      "recall_empty_total",
+		Help:      "How many times a recall returns empty result, group by recall name.",
+	}, []string{
+		"scene",
+		"recall_name",
+	})
+
 	RecallItemsPercentage = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Subsystem: subsystem,
 		Name:      "recall_items_percentage",
@@ -130,6 +143,16 @@ func initMetrics(conf *recconf.RecommendConfig) {
 		Buckets:   buckets,
 		Help:      "The recall cost in seconds.",
 	}, commonLabels)
+
+	RecallDurByName = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Subsystem: subsystem,
+		Name:      "recall_duration_by_name_seconds",
+		Buckets:   buckets,
+		Help:      "The single recall cost in seconds, group by recall name.",
+	}, []string{
+		"scene",
+		"recall_name",
+	})
 
 	FilterDurSecs = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Subsystem: subsystem,

--- a/service/recall.go
+++ b/service/recall.go
@@ -12,6 +12,7 @@ import (
 	"github.com/alibaba/pairec/v2/context"
 	"github.com/alibaba/pairec/v2/log"
 	"github.com/alibaba/pairec/v2/module"
+	"github.com/alibaba/pairec/v2/service/metrics"
 	"github.com/alibaba/pairec/v2/service/recall"
 	"github.com/alibaba/pairec/v2/utils"
 )
@@ -56,6 +57,10 @@ func (s *RecallService) GetItems(user *module.User, context *context.RecommendCo
 
 	var recalls []recall.Recall
 	var recallNames []string
+	// metricNames keeps the original recall name aligned with recalls (index by index),
+	// so metrics labels stay correct even when some recallNames are skipped below.
+	// Use the original config name (not the AB-cloned name) to avoid label cardinality explosion.
+	var metricNames []string
 	if context.ExperimentResult != nil {
 		names := context.ExperimentResult.GetExperimentParams().Get(categoryName+".RecallNames", nil)
 		if names != nil {
@@ -121,18 +126,27 @@ func (s *RecallService) GetItems(user *module.User, context *context.RecommendCo
 		}
 
 		recalls = append(recalls, r)
+		metricNames = append(metricNames, name)
 	}
 
 	ch := make(chan []*module.Item, len(recalls))
 
+	scene, _ := sceneName.(string)
+
 	start := time.Now()
 	for i := 0; i < len(recalls); i++ {
-		go func(ch chan<- []*module.Item, recall recall.Recall) {
+		go func(ch chan<- []*module.Item, recall recall.Recall, recallName string) {
+			recallStart := time.Now()
 			// when recall is panic, can recover it
 			defer func() {
 				if err := recover(); err != nil {
 					stack := string(debug.Stack())
 					log.Error(fmt.Sprintf("error=%v, stack=%s", err, strings.ReplaceAll(stack, "\n", "\t")))
+
+					if metrics.Enabled() {
+						// treat panic as an empty result
+						metrics.RecallEmptyTotal.WithLabelValues(scene, recallName).Inc()
+					}
 
 					var tmp []*module.Item
 					ch <- tmp
@@ -140,8 +154,16 @@ func (s *RecallService) GetItems(user *module.User, context *context.RecommendCo
 			}()
 
 			items := recall.GetCandidateItems(user, context)
+
+			if metrics.Enabled() {
+				metrics.RecallDurByName.WithLabelValues(scene, recallName).Observe(time.Since(recallStart).Seconds())
+				if len(items) == 0 {
+					metrics.RecallEmptyTotal.WithLabelValues(scene, recallName).Inc()
+				}
+			}
+
 			ch <- items
-		}(ch, recalls[i])
+		}(ch, recalls[i], metricNames[i])
 	}
 	for i := 0; i < len(recalls); i++ {
 		items := <-ch


### PR DESCRIPTION
## What
为每个召回单独记录耗时与为空次数，新增两个 Prometheus 指标：
- `recall_duration_by_name_seconds` (HistogramVec, labels: scene, recall_name)
- `recall_empty_total` (CounterVec, labels: scene, recall_name)

## How
- 在 `RecallService.GetItems` 的并发调度处埋点：逐召回计时上报耗时；`len(items)==0` 计入为空；panic（recover）也计入为空。
- 全部由 `metrics.Enabled()` 守卫，未开 Prometheus 时零影响。
- label 使用原始召回配置名（非 AB 克隆名 `xxx#md5`），避免时序基数膨胀。
- 顺带修复 `recalls` 与召回名的下标错位隐患（新增对齐的 `metricNames` 切片）。

## Impact
- 纯新增指标，未改动既有 `RecallDurSecs`/`RecallCount` 及召回执行逻辑，可安全回滚。