### PR TITLE
fix: make HA3 chat analyzer optional

### DIFF
--- a/service/recall/ha3_chat_recall.go
+++ b/service/recall/ha3_chat_recall.go
@@ -85,9 +85,11 @@ func (r *Ha3ChatRecall) Search(ctx context.Context, req SearchGoodsRequest) (*Se
 			"hit":    req.Limit,
 			"format": "json",
 		},
-		"analyzer": map[string]interface{}{
+	}
+	if r.conf.Analyzer != "" {
+		body["analyzer"] = map[string]interface{}{
 			r.conf.DefaultField: r.conf.Analyzer,
-		},
+		}
 	}
 	if filterExpr != "" {
 		body["filter"] = filterExpr


### PR DESCRIPTION
## Summary

- omit the Ha3 `analyzer` request clause when `Ha3ChatRecallConfig.Analyzer` is empty
- preserve the existing request body when an analyzer is configured

## Why

The `default` index field already has its analyzer configured in OpenSearch. Sending an incompatible query analyzer forced valid product queries to return zero results. An empty Analyzer setting should therefore mean “use the index field analyzer,” rather than sending an empty analyzer name.

## Impact

Existing configurations with a non-empty Analyzer are unchanged. Configurations can now leave Analyzer empty to use the analyzer defined by the OpenSearch index field.

## Validation

- `gofmt` and `git diff --check`
- `GOCACHE=/private/tmp/codex-go-cache-ai-shopping go test ./service/recall -run '^$'`
- rebuilt and started the local PAI-Rec AI shopping service with Analyzer empty
- Python end-to-end chat request completed with HTTP 200 and SSE `stop`; `search_goods(["Shirt"], AND)` returned total 10,542 / 12 hits and produced 8 product citations

`go test ./service/recall` was also attempted; the existing `TestMultibizRecall` panics from a nil dependency on the current master branch, unrelated to this change.
