### PR TITLE
feat: add knowledge vector grounding for AI shopping

### DIFF
--- a/algorithm/aichat/tool_schema.go
+++ b/algorithm/aichat/tool_schema.go
@@ -39,63 +39,70 @@ func SearchGoodsTool() Tool {
 	}
 }
 
-func FieldAwareSearchGoodsTool() Tool {
+func FieldAwareSearchGoodsTool(knowledgeCandidateIDs []string) Tool {
+	properties := map[string]interface{}{
+		"keywords": map[string]interface{}{
+			"type":        "array",
+			"items":       map[string]interface{}{"type": "string"},
+			"minItems":    1,
+			"maxItems":    1,
+			"description": "One complete positive English catalog search phrase. For English input, preserve the full positive phrase; for non-English input, translate the whole positive intent into one English catalog phrase. Remove explicit price and exclusion syntax, and never split the phrase across array items.",
+		},
+		"operator": map[string]interface{}{
+			"type":        "string",
+			"enum":        []string{"AND"},
+			"description": "Always AND, matching the current PAI-Rec Planner contract.",
+		},
+		"product_type_keywords": map[string]interface{}{
+			"type":        "array",
+			"items":       map[string]interface{}{"type": "string"},
+			"minItems":    1,
+			"maxItems":    4,
+			"description": "English catalog terms for the exact requested product type: the noun plus equivalent singular, plural, or common catalog forms; never adjacent product types.",
+		},
+		"attribute_keywords": map[string]interface{}{
+			"type":        "array",
+			"items":       map[string]interface{}{"type": "string"},
+			"maxItems":    5,
+			"description": "Positive English catalog descriptors for color, material, style, occasion, gender, age, size, or features; exclude product type, price, and negated values.",
+		},
+		"exclude_keywords": map[string]interface{}{
+			"type":        "array",
+			"items":       map[string]interface{}{"type": "string"},
+			"maxItems":    5,
+			"description": "English catalog attributes explicitly rejected by the Query; translate them to English and never infer exclusions.",
+		},
+		"min_price": map[string]interface{}{
+			"type":             "number",
+			"exclusiveMinimum": 0,
+			"description":      "Inclusive positive CNY minimum, emitted only when explicit.",
+		},
+		"max_price": map[string]interface{}{
+			"type":             "number",
+			"exclusiveMinimum": 0,
+			"description":      "Inclusive positive CNY maximum, emitted only when explicit.",
+		},
+	}
+	required := []string{"keywords", "operator", "product_type_keywords", "attribute_keywords"}
+	if len(knowledgeCandidateIDs) > 0 {
+		properties["knowledge_candidate_ids"] = map[string]interface{}{
+			"type":        "array",
+			"items":       map[string]interface{}{"type": "string", "enum": knowledgeCandidateIDs},
+			"maxItems":    4,
+			"uniqueItems": true,
+			"description": "Select only candidate IDs that exactly match the requested product type. Return an empty array when none matches. Never invent an ID.",
+		}
+		required = append(required, "knowledge_candidate_ids")
+	}
 	return Tool{
 		Type: "function",
 		Function: ToolFunction{
 			Name:        "search_goods",
 			Description: "Parse one product-shopping query in any language and search real products from the English-language catalog.",
 			Parameters: map[string]interface{}{
-				"type": "object",
-				"properties": map[string]interface{}{
-					"keywords": map[string]interface{}{
-						"type":        "array",
-						"items":       map[string]interface{}{"type": "string"},
-						"minItems":    1,
-						"maxItems":    1,
-						"description": "One complete positive English catalog search phrase. For English input, preserve the full positive phrase; for non-English input, translate the whole positive intent into one English catalog phrase. Remove explicit price and exclusion syntax, and never split the phrase across array items.",
-					},
-					"operator": map[string]interface{}{
-						"type":        "string",
-						"enum":        []string{"AND"},
-						"description": "Always AND, matching the current PAI-Rec Planner contract.",
-					},
-					"product_type_keywords": map[string]interface{}{
-						"type":        "array",
-						"items":       map[string]interface{}{"type": "string"},
-						"minItems":    1,
-						"maxItems":    4,
-						"description": "English catalog terms for the exact requested product type: the noun plus equivalent singular, plural, or common catalog forms; never adjacent product types.",
-					},
-					"attribute_keywords": map[string]interface{}{
-						"type":        "array",
-						"items":       map[string]interface{}{"type": "string"},
-						"maxItems":    5,
-						"description": "Positive English catalog descriptors for color, material, style, occasion, gender, age, size, or features; exclude product type, price, and negated values.",
-					},
-					"exclude_keywords": map[string]interface{}{
-						"type":        "array",
-						"items":       map[string]interface{}{"type": "string"},
-						"maxItems":    5,
-						"description": "English catalog attributes explicitly rejected by the Query; translate them to English and never infer exclusions.",
-					},
-					"min_price": map[string]interface{}{
-						"type":             "number",
-						"exclusiveMinimum": 0,
-						"description":      "Inclusive positive CNY minimum, emitted only when explicit.",
-					},
-					"max_price": map[string]interface{}{
-						"type":             "number",
-						"exclusiveMinimum": 0,
-						"description":      "Inclusive positive CNY maximum, emitted only when explicit.",
-					},
-				},
-				"required": []string{
-					"keywords",
-					"operator",
-					"product_type_keywords",
-					"attribute_keywords",
-				},
+				"type":                 "object",
+				"properties":           properties,
+				"required":             required,
 				"additionalProperties": false,
 			},
 		},

--- a/persist/fs/featurestore.go
+++ b/persist/fs/featurestore.go
@@ -12,11 +12,23 @@ import (
 var fsInstances = make(map[string]*FSClient)
 
 func GetFeatureStoreClient(name string) (*FSClient, error) {
-	if _, ok := fsInstances[name]; !ok {
-		return nil, fmt.Errorf("feature store client not found, name:%s", name)
+	if client, ok := fsInstances[name]; ok {
+		return client, nil
 	}
-
-	return fsInstances[name], nil
+	var matched *FSClient
+	for _, client := range fsInstances {
+		if client.projectName != name {
+			continue
+		}
+		if matched != nil {
+			return nil, fmt.Errorf("multiple feature store clients found for project:%s", name)
+		}
+		matched = client
+	}
+	if matched == nil {
+		return nil, fmt.Errorf("feature store client not found, name or project:%s", name)
+	}
+	return matched, nil
 }
 
 type FSClient struct {
@@ -27,6 +39,10 @@ type FSClient struct {
 
 func (fs *FSClient) GetProject() *domain.Project {
 	return fs.project
+}
+
+func (fs *FSClient) GetLLMConfig(name string) (*domain.LLMConfig, error) {
+	return fs.client.GetLLMConfig(name)
 }
 
 func (fs *FSClient) ReloadProject() {

--- a/persist/fs/featurestore.go
+++ b/persist/fs/featurestore.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/alibaba/pairec/v2/log"
 	"github.com/alibaba/pairec/v2/recconf"
@@ -9,9 +10,14 @@ import (
 	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/featurestore"
 )
 
-var fsInstances = make(map[string]*FSClient)
+var (
+	fsInstancesMu sync.RWMutex
+	fsInstances   = make(map[string]*FSClient)
+)
 
 func GetFeatureStoreClient(name string) (*FSClient, error) {
+	fsInstancesMu.RLock()
+	defer fsInstancesMu.RUnlock()
 	if client, ok := fsInstances[name]; ok {
 		return client, nil
 	}
@@ -55,7 +61,10 @@ func (fs *FSClient) ReloadProject() {
 
 func Load(config *recconf.RecommendConfig) {
 	for name, conf := range config.FeatureStoreConfs {
-		if fs, ok := fsInstances[name]; ok {
+		fsInstancesMu.RLock()
+		fs, ok := fsInstances[name]
+		fsInstancesMu.RUnlock()
+		if ok {
 			fs.ReloadProject()
 			continue
 		}
@@ -107,6 +116,8 @@ func Load(config *recconf.RecommendConfig) {
 			project:     p,
 			projectName: conf.ProjectName,
 		}
+		fsInstancesMu.Lock()
 		fsInstances[name] = m
+		fsInstancesMu.Unlock()
 	}
 }

--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -378,8 +378,9 @@ type RecallConfig struct {
 	// recall engine config
 	RecallEngineConf RecallEngineConfig
 
-	Ha3ChatRecallConf Ha3ChatRecallConfig
-	FilterParams      []FilterParamConfig
+	Ha3ChatRecallConf      Ha3ChatRecallConfig
+	Ha3KnowledgeVectorConf *Ha3KnowledgeVectorConfig
+	FilterParams           []FilterParamConfig
 }
 
 type Ha3ChatRecallConfig struct {
@@ -394,6 +395,22 @@ type Ha3ChatRecallConfig struct {
 	TagsField       string
 	Analyzer        string
 	PriceField      string
+}
+
+type Ha3KnowledgeVectorConfig struct {
+	FeatureStoreName   string
+	LLMConfigName      string
+	IndexName          string
+	VectorIndexName    string
+	EmbeddingDelimiter string
+	KnowledgeIDField   string
+	KnowledgeTypeField string
+	KnowledgeTypes     []string
+	ValueField         string
+	CategoryField      string
+	TopK               int
+	SearchTimeout      int
+	QueryTemplate      string
 }
 
 type GraphConf struct {
@@ -783,19 +800,20 @@ type CategoryConfig struct {
 }
 
 type AIChatConfig struct {
-	DefaultLanguage         string
-	OutputLanguages         []string
-	PlannerPromptTemplates  map[string]string
-	ReplyPromptTemplates    map[string]string
-	FallbackTemplates       map[string]map[string]string
-	ToolMaxRounds           int
-	DisplayItemCountMax     int
-	LLMAlgoName             string
-	RecallName              string
-	SessionFeatureStoreName string
-	SessionFeatureView      string
-	SessionMaxTurns         int
-	SessionMaxTokens        int
+	DefaultLanguage             string
+	OutputLanguages             []string
+	PlannerPromptTemplates      map[string]string
+	ReplyPromptTemplates        map[string]string
+	FallbackTemplates           map[string]map[string]string
+	ToolMaxRounds               int
+	DisplayItemCountMax         int
+	LLMAlgoName                 string
+	RecallName                  string
+	KnowledgePlannerInstruction string
+	SessionFeatureStoreName     string
+	SessionFeatureView          string
+	SessionMaxTurns             int
+	SessionMaxTokens            int
 }
 
 type FallbackConfig struct {

--- a/service/aishopping/agent_loop.go
+++ b/service/aishopping/agent_loop.go
@@ -61,7 +61,7 @@ func (r toolDispatchResult) shouldRetryWithFallback(tried bool) bool {
 	return r.isSearch && !r.hasError && r.operator == "AND" && r.total == 0 && r.keywordCount > 1 && !tried
 }
 
-func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, blob *SessionBlob, cfg *chatConfig, writer *StreamWriter, meta timingMeta) (*agentLoopResult, error) {
+func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, blob *SessionBlob, cfg *chatConfig, knowledge *knowledgeEvidence, writer *StreamWriter, meta timingMeta) (*agentLoopResult, error) {
 	state := &turnState{
 		indexMap:    make(map[int]string),
 		itemToIndex: make(map[string]int),
@@ -96,9 +96,13 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 				Content: fieldAwareSearchRetryMessage,
 			})
 		}
+		plannerMessages := messagesWithPrompt(messages, prompt)
+		if !readyToReply {
+			plannerMessages = messagesWithKnowledge(plannerMessages, cfg.raw.KnowledgePlannerInstruction, knowledge)
+		}
 		llmReq := &aichat.ChatCompletionRequest{
 			Model:          "",
-			Messages:       messagesWithPrompt(messages, prompt),
+			Messages:       plannerMessages,
 			Tools:          []aichat.Tool{aichat.SearchGoodsTool()},
 			Stream:         true,
 			EnableThinking: false,
@@ -107,7 +111,7 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 			plannerAttempts++
 			temperature := 0.0
 			parallelToolCalls := false
-			llmReq.Tools = []aichat.Tool{aichat.FieldAwareSearchGoodsTool()}
+			llmReq.Tools = []aichat.Tool{aichat.FieldAwareSearchGoodsTool(knowledge.candidateIDs())}
 			llmReq.Temperature = &temperature
 			llmReq.ParallelToolCalls = &parallelToolCalls
 		}
@@ -164,7 +168,7 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 			result.ToolCalls = nil
 		}
 		if fieldAwareSearch && !readyToReply {
-			if err := normalizeFieldAwareToolCalls(result.ToolCalls); err != nil {
+			if err := normalizeFieldAwareToolCalls(result.ToolCalls, knowledge); err != nil {
 				plannerRetry = true
 				log.Warning(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=planner_retry\tround=%d\tattempt=%d\terr=%s\targs=%s",
 					meta.requestId, meta.uid, meta.sessionId, round, plannerAttempts, compactLogError(err), fieldAwareToolArguments(result.ToolCalls)))
@@ -210,7 +214,7 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 		for i, toolCall := range result.ToolCalls {
 			log.Info(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=tool_call_args\tround=%d\ttoolIndex=%d\ttool=%s\targs=%s",
 				meta.requestId, meta.uid, meta.sessionId, round, i, toolCall.Function.Name, compactJSONString(toolCall.Function.Arguments, toolArgumentsLogLimit)))
-			toolResult := dispatchTool(ctx, recall, toolCall, state, cfg.raw.DisplayItemCountMax, fieldAwareSearch, meta, round)
+			toolResult := dispatchTool(ctx, recall, toolCall, state, cfg.raw.DisplayItemCountMax, fieldAwareSearch, knowledge, meta, round)
 			blob.Messages = append(blob.Messages, aichat.Message{
 				Role:       "tool",
 				ToolCallId: toolCall.ID,
@@ -231,11 +235,11 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 	}, nil
 }
 
-func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCall, state *turnState, limit int, fieldAware bool, meta timingMeta, round int) toolDispatchResult {
+func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCall, state *turnState, limit int, fieldAware bool, knowledge *knowledgeEvidence, meta timingMeta, round int) toolDispatchResult {
 	if toolCall.Function.Name != "search_goods" {
 		return toolDispatchResult{content: `{"error":"unsupported tool"}`, hasError: true}
 	}
-	req, err := parseSearchGoodsRequest(toolCall.Function.Arguments, fieldAware)
+	req, err := parseSearchGoodsRequest(toolCall.Function.Arguments, fieldAware, knowledge)
 	if err != nil {
 		log.Error(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=tool_parse\tround=%d\terr=%v\targs=%s",
 			meta.requestId, meta.uid, meta.sessionId, round, err, compactJSONString(toolCall.Function.Arguments, toolArgumentsLogLimit)))
@@ -275,7 +279,7 @@ func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCa
 	return dispatchResult
 }
 
-func normalizeFieldAwareToolCalls(toolCalls []aichat.ToolCall) error {
+func normalizeFieldAwareToolCalls(toolCalls []aichat.ToolCall, knowledge *knowledgeEvidence) error {
 	if len(toolCalls) != 1 || toolCalls[0].Function.Name != "search_goods" {
 		return fmt.Errorf("exactly one search_goods call is required")
 	}
@@ -285,16 +289,29 @@ func normalizeFieldAwareToolCalls(toolCalls []aichat.ToolCall) error {
 	if toolCalls[0].Type != "function" {
 		return fmt.Errorf("search_goods tool call type must be function")
 	}
-	req, err := parseSearchGoodsRequest(toolCalls[0].Function.Arguments, true)
+	req, err := parseSearchGoodsRequest(toolCalls[0].Function.Arguments, true, knowledge)
 	if err != nil {
 		return err
 	}
-	arguments, err := json.Marshal(req)
+	arguments, err := marshalSearchGoodsRequest(req, knowledge)
 	if err != nil {
 		return err
 	}
 	toolCalls[0].Function.Arguments = string(arguments)
 	return nil
+}
+
+func marshalSearchGoodsRequest(req recallsvc.SearchGoodsRequest, knowledge *knowledgeEvidence) ([]byte, error) {
+	payload, err := json.Marshal(req)
+	if err != nil || knowledge == nil || len(req.KnowledgeCandidateIDs) > 0 {
+		return payload, err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(payload, &fields); err != nil {
+		return nil, err
+	}
+	fields["knowledge_candidate_ids"] = json.RawMessage(`[]`)
+	return json.Marshal(fields)
 }
 
 func fieldAwareToolArguments(toolCalls []aichat.ToolCall) string {
@@ -304,7 +321,7 @@ func fieldAwareToolArguments(toolCalls []aichat.ToolCall) string {
 	return compactJSONString(toolCalls[0].Function.Arguments, toolArgumentsLogLimit)
 }
 
-func parseSearchGoodsRequest(arguments string, fieldAware bool) (recallsvc.SearchGoodsRequest, error) {
+func parseSearchGoodsRequest(arguments string, fieldAware bool, knowledge *knowledgeEvidence) (recallsvc.SearchGoodsRequest, error) {
 	var req recallsvc.SearchGoodsRequest
 	if !fieldAware {
 		return req, json.Unmarshal([]byte(arguments), &req)
@@ -338,6 +355,9 @@ func parseSearchGoodsRequest(arguments string, fieldAware bool) (recallsvc.Searc
 		if err == nil {
 			err = fmt.Errorf("multiple JSON values are not allowed")
 		}
+		return req, err
+	}
+	if err := knowledge.apply(&req); err != nil {
 		return req, err
 	}
 	return recallsvc.NormalizeFieldAwareSearchGoodsRequest(req)

--- a/service/aishopping/citation.go
+++ b/service/aishopping/citation.go
@@ -101,3 +101,21 @@ func messagesWithPrompt(messages []aichat.Message, prompt string) []aichat.Messa
 	copied[0] = aichat.Message{Role: "system", Content: prompt}
 	return copied
 }
+
+func messagesWithKnowledge(messages []aichat.Message, instruction string, evidence *knowledgeEvidence) []aichat.Message {
+	if evidence == nil {
+		return messages
+	}
+	knowledgeMessages := []aichat.Message{
+		{Role: "system", Content: instruction},
+		{Role: "system", Content: "KNOWLEDGE_CANDIDATES_JSON:\n" + evidence.promptJSON},
+	}
+	if len(messages) == 0 {
+		return knowledgeMessages
+	}
+	result := make([]aichat.Message, 0, len(messages)+len(knowledgeMessages))
+	result = append(result, messages[0])
+	result = append(result, knowledgeMessages...)
+	result = append(result, messages[1:]...)
+	return result
+}

--- a/service/aishopping/config.go
+++ b/service/aishopping/config.go
@@ -2,6 +2,7 @@ package aishopping
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/alibaba/pairec/v2/recconf"
 )
@@ -36,12 +37,21 @@ func resolveConfig(config *recconf.RecommendConfig, sceneId, language string) (*
 	if _, ok := cfg.FallbackTemplates[language]; !ok {
 		return nil, fmt.Errorf("fallback_missing:%s", language)
 	}
+	fieldAware := isFieldAwareRecall(config.RecallConfs, cfg.RecallName)
+	knowledgeConfigured := isKnowledgeRecall(config.RecallConfs, cfg.RecallName)
+	if knowledgeConfigured && strings.TrimSpace(cfg.KnowledgePlannerInstruction) == "" {
+		return nil, fmt.Errorf("KnowledgePlannerInstruction is required when Ha3KnowledgeVectorConf is configured")
+	}
+	if knowledgeConfigured && !fieldAware {
+		return nil, fmt.Errorf("Ha3KnowledgeVectorConf requires field-aware Ha3ChatRecallConf")
+	}
 	return &chatConfig{
-		raw:           cfg,
-		language:      language,
-		plannerPrompt: plannerPrompt,
-		replyPrompt:   replyPrompt,
-		fieldAware:    isFieldAwareRecall(config.RecallConfs, cfg.RecallName),
+		raw:                 cfg,
+		language:            language,
+		plannerPrompt:       plannerPrompt,
+		replyPrompt:         replyPrompt,
+		fieldAware:          fieldAware,
+		knowledgeConfigured: knowledgeConfigured,
 	}, nil
 }
 
@@ -50,6 +60,15 @@ func isFieldAwareRecall(recallConfs []recconf.RecallConfig, recallName string) b
 		if recallConf.Name == recallName {
 			conf := recallConf.Ha3ChatRecallConf
 			return conf.TitleField != "" && conf.CategoryField != ""
+		}
+	}
+	return false
+}
+
+func isKnowledgeRecall(recallConfs []recconf.RecallConfig, recallName string) bool {
+	for _, recallConf := range recallConfs {
+		if recallConf.Name == recallName {
+			return recallConf.Ha3KnowledgeVectorConf != nil
 		}
 	}
 	return false

--- a/service/aishopping/knowledge_prompt.go
+++ b/service/aishopping/knowledge_prompt.go
@@ -1,0 +1,163 @@
+package aishopping
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	recallsvc "github.com/alibaba/pairec/v2/service/recall"
+)
+
+const (
+	knowledgePromptMaxBytes          = 6000
+	knowledgeCandidateSelectionLimit = 4
+)
+
+type knowledgeCandidate struct {
+	KnowledgeID   string `json:"-"`
+	CandidateID   string `json:"candidate_id"`
+	KnowledgeType string `json:"knowledge_type"`
+	Value         string `json:"value"`
+	Category      string `json:"category"`
+	SearchTerm    string `json:"search_term"`
+}
+
+type knowledgeEvidence struct {
+	candidates []knowledgeCandidate
+	byID       map[string]knowledgeCandidate
+	promptJSON string
+}
+
+func newKnowledgeEvidence(result *recallsvc.KnowledgeSearchResult) *knowledgeEvidence {
+	if result == nil || len(result.Hits) == 0 {
+		return nil
+	}
+	evidence := &knowledgeEvidence{byID: make(map[string]knowledgeCandidate)}
+	seen := make(map[string]struct{}, len(result.Hits))
+	seenKnowledgeIDs := make(map[string]struct{}, len(result.Hits))
+	for _, hit := range result.Hits {
+		if _, ok := seenKnowledgeIDs[hit.KnowledgeID]; ok {
+			continue
+		}
+		searchTerm := knowledgeSearchTerm(hit.KnowledgeType, hit.Value)
+		if searchTerm == "" || hit.Category == "" {
+			continue
+		}
+		key := strings.ToLower(hit.KnowledgeType + "\x00" + searchTerm + "\x00" + hit.Category)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		candidate := knowledgeCandidate{
+			KnowledgeID:   hit.KnowledgeID,
+			CandidateID:   fmt.Sprintf("K%d", len(evidence.candidates)+1),
+			KnowledgeType: hit.KnowledgeType,
+			Value:         hit.Value,
+			Category:      hit.Category,
+			SearchTerm:    searchTerm,
+		}
+		prospective := append(append([]knowledgeCandidate(nil), evidence.candidates...), candidate)
+		payload, err := json.Marshal(prospective)
+		if err != nil || len(payload) > knowledgePromptMaxBytes {
+			break
+		}
+		seen[key] = struct{}{}
+		seenKnowledgeIDs[hit.KnowledgeID] = struct{}{}
+		evidence.candidates = prospective
+		evidence.byID[candidate.CandidateID] = candidate
+		evidence.promptJSON = string(payload)
+	}
+	if len(evidence.candidates) == 0 {
+		return nil
+	}
+	return evidence
+}
+
+func (e *knowledgeEvidence) logSummary() []map[string]string {
+	if e == nil {
+		return nil
+	}
+	result := make([]map[string]string, 0, len(e.candidates))
+	for _, candidate := range e.candidates {
+		result = append(result, map[string]string{
+			"candidate_id":   candidate.CandidateID,
+			"knowledge_id":   candidate.KnowledgeID,
+			"knowledge_type": candidate.KnowledgeType,
+			"search_term":    candidate.SearchTerm,
+			"category":       candidate.Category,
+		})
+	}
+	return result
+}
+
+func knowledgeSearchTerm(knowledgeType, value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if knowledgeType != "categories" {
+		return value
+	}
+	parts := strings.FieldsFunc(value, func(r rune) bool { return r == '/' || r == '>' })
+	for index := len(parts) - 1; index >= 0; index-- {
+		if part := strings.TrimSpace(parts[index]); part != "" {
+			return part
+		}
+	}
+	return ""
+}
+
+func (e *knowledgeEvidence) candidateIDs() []string {
+	if e == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(e.candidates))
+	for _, candidate := range e.candidates {
+		ids = append(ids, candidate.CandidateID)
+	}
+	return ids
+}
+
+func (e *knowledgeEvidence) apply(req *recallsvc.SearchGoodsRequest) error {
+	if e == nil {
+		if len(req.KnowledgeCandidateIDs) > 0 {
+			return fmt.Errorf("knowledge_candidate_ids is unavailable for this request")
+		}
+		return nil
+	}
+	if req.KnowledgeCandidateIDs == nil {
+		return fmt.Errorf("knowledge_candidate_ids is required")
+	}
+	if len(req.KnowledgeCandidateIDs) == 0 {
+		return nil
+	}
+	seenIDs := make(map[string]struct{}, len(req.KnowledgeCandidateIDs))
+	selectedIDs := make([]string, 0, knowledgeCandidateSelectionLimit)
+	searchTerms := make([]string, 0, knowledgeCandidateSelectionLimit)
+	seenTerms := make(map[string]struct{}, len(req.KnowledgeCandidateIDs))
+	for _, id := range req.KnowledgeCandidateIDs {
+		if _, exists := seenIDs[id]; exists {
+			return fmt.Errorf("knowledge_candidate_ids contains duplicate value %q", id)
+		}
+		seenIDs[id] = struct{}{}
+		candidate, exists := e.byID[id]
+		if !exists {
+			return fmt.Errorf("knowledge_candidate_ids contains unknown value %q", id)
+		}
+		key := strings.ToLower(candidate.SearchTerm)
+		if _, exists := seenTerms[key]; exists {
+			continue
+		}
+		seenTerms[key] = struct{}{}
+		if len(searchTerms) >= knowledgeCandidateSelectionLimit {
+			continue
+		}
+		selectedIDs = append(selectedIDs, id)
+		searchTerms = append(searchTerms, candidate.SearchTerm)
+	}
+	if len(searchTerms) == 0 {
+		return fmt.Errorf("knowledge_candidate_ids does not resolve to a search term")
+	}
+	req.KnowledgeCandidateIDs = selectedIDs
+	req.ProductTypeKeywords = searchTerms
+	return nil
+}

--- a/service/aishopping/orchestrator.go
+++ b/service/aishopping/orchestrator.go
@@ -57,7 +57,38 @@ func (o *ChatSearchOrchestrator) Run(ctx context.Context, req *Request, writer *
 		sceneId:   req.SceneId,
 		language:  cfg.language,
 	}
-	loopResult, err := runAgentLoop(ctx, model, chatRecall, blob, cfg, writer, meta)
+	var knowledge *knowledgeEvidence
+	if cfg.knowledgeConfigured {
+		knowledgeRecall, ok := chatRecall.(interface {
+			SearchKnowledge(context.Context, string) (*recallsvc.KnowledgeSearchResult, error)
+		})
+		if !ok {
+			return fmt.Errorf("recall %s does not support configured knowledge vector search", cfg.raw.RecallName)
+		}
+		knowledgeStart := time.Now()
+		knowledgeResult, knowledgeErr := knowledgeRecall.SearchKnowledge(ctx, req.UserText)
+		knowledgeCost := utils.CostTime(knowledgeStart)
+		if knowledgeErr != nil {
+			log.Warning(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=knowledge_recall\tstatus=degraded\tcost=%d\terr=%s",
+				meta.requestId, meta.uid, meta.sessionId, knowledgeCost, compactLogError(knowledgeErr)))
+		} else {
+			if knowledgeResult == nil {
+				knowledgeResult = &recallsvc.KnowledgeSearchResult{}
+			}
+			knowledge = newKnowledgeEvidence(knowledgeResult)
+			candidateCount := 0
+			candidateSummary := "[]"
+			if knowledge != nil {
+				candidateCount = len(knowledge.candidates)
+				candidateSummary = compactJSON(knowledge.logSummary())
+			}
+			log.Info(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=knowledge_recall\tstatus=ok\ttotal=%d\thits=%d\tcandidates=%d\tembeddingDimension=%d\tembeddingAttempts=%d\tembeddingCost=%d\tsearchCost=%d\tcost=%d\tcandidateSummary=%s",
+				meta.requestId, meta.uid, meta.sessionId, knowledgeResult.Total, len(knowledgeResult.Hits), candidateCount,
+				knowledgeResult.EmbeddingDimension, knowledgeResult.EmbeddingAttempts, knowledgeResult.EmbeddingCostMs,
+				knowledgeResult.SearchCostMs, knowledgeCost, compactJSONString(candidateSummary, toolArgumentsLogLimit)))
+		}
+	}
+	loopResult, err := runAgentLoop(ctx, model, chatRecall, blob, cfg, knowledge, writer, meta)
 	if err != nil {
 		log.Error(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=upstream\terr=%v",
 			req.RequestId, req.Uid, req.SessionId, err))

--- a/service/aishopping/types.go
+++ b/service/aishopping/types.go
@@ -24,9 +24,10 @@ type SessionBlob struct {
 }
 
 type chatConfig struct {
-	raw           *recconf.AIChatConfig
-	language      string
-	plannerPrompt string
-	replyPrompt   string
-	fieldAware    bool
+	raw                 *recconf.AIChatConfig
+	language            string
+	plannerPrompt       string
+	replyPrompt         string
+	fieldAware          bool
+	knowledgeConfigured bool
 }

--- a/service/recall/ha3_chat_knowledge.go
+++ b/service/recall/ha3_chat_knowledge.go
@@ -1,0 +1,275 @@
+package recall
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/alibaba/pairec/v2/datasource/ha3engine/ha3client"
+	"github.com/alibaba/pairec/v2/recconf"
+	"github.com/alibabacloud-go/tea/tea"
+	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/domain"
+)
+
+const (
+	defaultKnowledgeTopK          = 20
+	defaultKnowledgeSearchTimeout = 2500
+	knowledgeEmbeddingTimeout     = 5 * time.Second
+	knowledgeEmbeddingAttempts    = 2
+)
+
+var validKnowledgeTypes = map[string]struct{}{
+	"category":   {},
+	"categories": {},
+	"content":    {},
+	"brand":      {},
+	"tag":        {},
+	"title":      {},
+}
+
+type KnowledgeHit struct {
+	KnowledgeID   string      `json:"knowledge_id"`
+	KnowledgeType string      `json:"knowledge_type"`
+	Value         string      `json:"value"`
+	Category      string      `json:"category"`
+	Score         interface{} `json:"score,omitempty"`
+}
+
+type KnowledgeSearchResult struct {
+	Total              int            `json:"total"`
+	Hits               []KnowledgeHit `json:"hits"`
+	EmbeddingDimension int            `json:"embedding_dimension"`
+	EmbeddingAttempts  int            `json:"embedding_attempts"`
+	EmbeddingCostMs    int64          `json:"embedding_cost_ms"`
+	SearchCostMs       int64          `json:"search_cost_ms"`
+}
+
+func normalizeHa3KnowledgeVectorConfig(conf recconf.Ha3KnowledgeVectorConfig) recconf.Ha3KnowledgeVectorConfig {
+	conf.FeatureStoreName = strings.TrimSpace(conf.FeatureStoreName)
+	conf.LLMConfigName = strings.TrimSpace(conf.LLMConfigName)
+	conf.IndexName = strings.TrimSpace(conf.IndexName)
+	conf.VectorIndexName = strings.TrimSpace(conf.VectorIndexName)
+	conf.KnowledgeIDField = strings.TrimSpace(conf.KnowledgeIDField)
+	conf.KnowledgeTypeField = strings.TrimSpace(conf.KnowledgeTypeField)
+	conf.ValueField = strings.TrimSpace(conf.ValueField)
+	conf.CategoryField = strings.TrimSpace(conf.CategoryField)
+	conf.QueryTemplate = strings.TrimSpace(conf.QueryTemplate)
+	if conf.EmbeddingDelimiter == "" {
+		conf.EmbeddingDelimiter = "\x1d"
+	}
+	if conf.TopK <= 0 {
+		conf.TopK = defaultKnowledgeTopK
+	}
+	if conf.SearchTimeout <= 0 {
+		conf.SearchTimeout = defaultKnowledgeSearchTimeout
+	}
+	conf.KnowledgeTypes = append([]string(nil), conf.KnowledgeTypes...)
+	for index := range conf.KnowledgeTypes {
+		conf.KnowledgeTypes[index] = strings.TrimSpace(conf.KnowledgeTypes[index])
+	}
+	return conf
+}
+
+func validateHa3KnowledgeVectorConfig(conf recconf.Ha3KnowledgeVectorConfig) {
+	required := []struct {
+		name  string
+		value string
+	}{
+		{name: "FeatureStoreName", value: conf.FeatureStoreName},
+		{name: "LLMConfigName", value: conf.LLMConfigName},
+		{name: "IndexName", value: conf.IndexName},
+		{name: "VectorIndexName", value: conf.VectorIndexName},
+		{name: "KnowledgeIDField", value: conf.KnowledgeIDField},
+		{name: "KnowledgeTypeField", value: conf.KnowledgeTypeField},
+		{name: "ValueField", value: conf.ValueField},
+		{name: "CategoryField", value: conf.CategoryField},
+		{name: "QueryTemplate", value: conf.QueryTemplate},
+	}
+	for _, field := range required {
+		if field.value == "" {
+			panic(fmt.Sprintf("Ha3KnowledgeVectorConf.%s is required", field.name))
+		}
+	}
+	fieldNames := required[2:8]
+	for _, field := range fieldNames {
+		if !validHa3FieldName(field.value) {
+			panic(fmt.Sprintf("Ha3KnowledgeVectorConf.%s has invalid name %q", field.name, field.value))
+		}
+	}
+	if len(conf.KnowledgeTypes) == 0 {
+		panic("Ha3KnowledgeVectorConf.KnowledgeTypes is required")
+	}
+	seen := make(map[string]struct{}, len(conf.KnowledgeTypes))
+	for _, knowledgeType := range conf.KnowledgeTypes {
+		if _, ok := validKnowledgeTypes[knowledgeType]; !ok {
+			panic(fmt.Sprintf("Ha3KnowledgeVectorConf.KnowledgeTypes contains unsupported value %q", knowledgeType))
+		}
+		if _, ok := seen[knowledgeType]; ok {
+			panic(fmt.Sprintf("Ha3KnowledgeVectorConf.KnowledgeTypes contains duplicate value %q", knowledgeType))
+		}
+		seen[knowledgeType] = struct{}{}
+	}
+	if strings.Count(conf.QueryTemplate, "{query}") != 1 {
+		panic("Ha3KnowledgeVectorConf.QueryTemplate must contain exactly one {query}")
+	}
+	if conf.TopK < 1 || conf.TopK > 100 {
+		panic("Ha3KnowledgeVectorConf.TopK must be between 1 and 100")
+	}
+	if conf.SearchTimeout < 1 {
+		panic("Ha3KnowledgeVectorConf.SearchTimeout must be positive")
+	}
+}
+
+func (r *Ha3ChatRecall) KnowledgeEnabled() bool {
+	return r.knowledgeConf != nil && r.knowledgeLLM != nil
+}
+
+func (r *Ha3ChatRecall) SearchKnowledge(ctx context.Context, query string) (*KnowledgeSearchResult, error) {
+	if !r.KnowledgeEnabled() {
+		return nil, nil
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, fmt.Errorf("knowledge query is empty")
+	}
+	conf := r.knowledgeConf
+	embeddingInput := strings.Replace(conf.QueryTemplate, "{query}", query, 1)
+	embeddingCtx, cancel := context.WithTimeout(ctx, knowledgeEmbeddingTimeout)
+	defer cancel()
+	embeddingStart := time.Now()
+	var (
+		vectors  [][]float32
+		err      error
+		attempts int
+	)
+	for attempts = 1; attempts <= knowledgeEmbeddingAttempts; attempts++ {
+		vectors, err = r.knowledgeLLM.CreateMultiModalEmbeddings(embeddingCtx, []domain.MultiModalContent{{Text: embeddingInput}})
+		if err == nil {
+			break
+		}
+		if embeddingCtx.Err() != nil {
+			return nil, embeddingCtx.Err()
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("create knowledge embedding failed after %d attempts: %w", attempts-1, err)
+	}
+	if len(vectors) != 1 {
+		return nil, fmt.Errorf("knowledge embedding returned %d vectors, want 1", len(vectors))
+	}
+	vectorText, err := encodeKnowledgeVector(vectors[0], conf.EmbeddingDelimiter)
+	if err != nil {
+		return nil, err
+	}
+	result := &KnowledgeSearchResult{
+		EmbeddingDimension: len(vectors[0]),
+		EmbeddingAttempts:  attempts,
+		EmbeddingCostMs:    time.Since(embeddingStart).Milliseconds(),
+	}
+	searchStart := time.Now()
+	searchResult, err := r.searchKnowledgeVector(ctx, vectorText)
+	result.SearchCostMs = time.Since(searchStart).Milliseconds()
+	if err != nil {
+		return nil, err
+	}
+	result.Total = searchResult.Total
+	result.Hits = searchResult.Hits
+	return result, nil
+}
+
+func encodeKnowledgeVector(vector []float32, delimiter string) (string, error) {
+	if len(vector) == 0 {
+		return "", fmt.Errorf("knowledge embedding vector is empty")
+	}
+	parts := make([]string, len(vector))
+	norm := float64(0)
+	for index, value := range vector {
+		if math.IsNaN(float64(value)) || math.IsInf(float64(value), 0) {
+			return "", fmt.Errorf("knowledge embedding vector contains invalid value at index %d", index)
+		}
+		norm += float64(value) * float64(value)
+		parts[index] = strconv.FormatFloat(float64(value), 'f', 9, 32)
+	}
+	if norm == 0 {
+		return "", fmt.Errorf("knowledge embedding vector has zero norm")
+	}
+	return strings.Join(parts, delimiter), nil
+}
+
+func (r *Ha3ChatRecall) searchKnowledgeVector(ctx context.Context, vectorText string) (*KnowledgeSearchResult, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	conf := r.knowledgeConf
+	filters := make([]string, 0, len(conf.KnowledgeTypes))
+	for _, knowledgeType := range conf.KnowledgeTypes {
+		filters = append(filters, fmt.Sprintf(`%s=%q`, conf.KnowledgeTypeField, knowledgeType))
+	}
+	body := map[string]interface{}{
+		"query":  fmt.Sprintf("%s:'%s&n=%d'", conf.VectorIndexName, vectorText, conf.TopK),
+		"filter": strings.Join(filters, " OR "),
+		"config": map[string]interface{}{
+			"start":   0,
+			"hit":     conf.TopK,
+			"format":  "json",
+			"timeout": conf.SearchTimeout,
+		},
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := r.client.Ha3Client.SearchRestWithOptions(
+		tea.String(conf.IndexName),
+		(&ha3client.SearchRequestModel{}).SetHeaders(map[string]*string{}).SetBody(string(payload)),
+		r.client.Runtime(),
+	)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
+	}
+	if err != nil {
+		return nil, err
+	}
+	return r.parseKnowledgeResponse(resp)
+}
+
+func (r *Ha3ChatRecall) parseKnowledgeResponse(resp *ha3client.SearchResponseModel) (*KnowledgeSearchResult, error) {
+	total, items, responseErrors, err := decodeHa3ChatResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+	if hasHa3ResponseErrors(responseErrors) {
+		payload, _ := json.Marshal(responseErrors)
+		return nil, fmt.Errorf("ha3 knowledge search errors: %s", payload)
+	}
+	hits := make([]KnowledgeHit, 0, len(items))
+	for _, item := range items {
+		itemMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		fields, _ := itemMap["fields"].(map[string]interface{})
+		if fields == nil {
+			fields = itemMap
+		}
+		hit := KnowledgeHit{
+			KnowledgeID:   strings.TrimSpace(stringFromAny(fields[r.knowledgeConf.KnowledgeIDField])),
+			KnowledgeType: strings.TrimSpace(stringFromAny(fields[r.knowledgeConf.KnowledgeTypeField])),
+			Value:         strings.TrimSpace(stringFromAny(fields[r.knowledgeConf.ValueField])),
+			Category:      strings.TrimSpace(stringFromAny(fields[r.knowledgeConf.CategoryField])),
+			Score:         firstAny(itemMap["sortExprValues"], itemMap["score"]),
+		}
+		if hit.KnowledgeID == "" || hit.KnowledgeType == "" || hit.Value == "" || hit.Category == "" {
+			continue
+		}
+		hits = append(hits, hit)
+	}
+	if len(items) > 0 && len(hits) == 0 {
+		return nil, fmt.Errorf("ha3 knowledge response contains %d items but none has all configured result fields", len(items))
+	}
+	return &KnowledgeSearchResult{Total: total, Hits: hits}, nil
+}

--- a/service/recall/ha3_chat_recall.go
+++ b/service/recall/ha3_chat_recall.go
@@ -12,8 +12,10 @@ import (
 	"github.com/alibaba/pairec/v2/datasource/ha3engine/ha3client"
 	"github.com/alibaba/pairec/v2/log"
 	"github.com/alibaba/pairec/v2/module"
+	"github.com/alibaba/pairec/v2/persist/fs"
 	"github.com/alibaba/pairec/v2/recconf"
 	"github.com/alibabacloud-go/tea/tea"
+	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/domain"
 )
 
 const (
@@ -23,20 +25,23 @@ const (
 
 type Ha3ChatRecall struct {
 	*BaseRecall
-	client *ha3engine.Ha3EngineClient
-	conf   recconf.Ha3ChatRecallConfig
+	client        *ha3engine.Ha3EngineClient
+	conf          recconf.Ha3ChatRecallConfig
+	knowledgeConf *recconf.Ha3KnowledgeVectorConfig
+	knowledgeLLM  *domain.LLMConfig
 }
 
 type SearchGoodsRequest struct {
-	Keywords            []string `json:"keywords"`
-	ProductTypeKeywords []string `json:"product_type_keywords"`
-	AttributeKeywords   []string `json:"attribute_keywords"`
-	Operator            string   `json:"operator"`
-	ExcludeKeywords     []string `json:"exclude_keywords,omitempty"`
-	MinPrice            *float64 `json:"min_price,omitempty"`
-	MaxPrice            *float64 `json:"max_price,omitempty"`
-	Limit               int      `json:"-"`
-	MultiFieldFallback  bool     `json:"-"`
+	Keywords              []string `json:"keywords"`
+	ProductTypeKeywords   []string `json:"product_type_keywords"`
+	AttributeKeywords     []string `json:"attribute_keywords"`
+	Operator              string   `json:"operator"`
+	ExcludeKeywords       []string `json:"exclude_keywords,omitempty"`
+	MinPrice              *float64 `json:"min_price,omitempty"`
+	MaxPrice              *float64 `json:"max_price,omitempty"`
+	Limit                 int      `json:"-"`
+	MultiFieldFallback    bool     `json:"-"`
+	KnowledgeCandidateIDs []string `json:"knowledge_candidate_ids,omitempty"`
 }
 
 type GoodsHit struct {
@@ -69,11 +74,34 @@ func NewHa3ChatRecall(config recconf.RecallConfig) *Ha3ChatRecall {
 		}
 	}
 	validateHa3ChatFieldConfig(conf)
-	return &Ha3ChatRecall{
+	if config.Ha3KnowledgeVectorConf != nil && !ha3ChatFieldAwareConfigured(conf) {
+		panic("Ha3KnowledgeVectorConf requires field-aware Ha3ChatRecallConf")
+	}
+	recall := &Ha3ChatRecall{
 		BaseRecall: NewBaseRecall(config),
 		client:     client,
 		conf:       conf,
 	}
+	if config.Ha3KnowledgeVectorConf != nil {
+		knowledgeConf := normalizeHa3KnowledgeVectorConfig(*config.Ha3KnowledgeVectorConf)
+		validateHa3KnowledgeVectorConfig(knowledgeConf)
+		fsClient, err := fs.GetFeatureStoreClient(knowledgeConf.FeatureStoreName)
+		if err != nil {
+			panic(err)
+		}
+		llmConfig, err := fsClient.GetLLMConfig(knowledgeConf.LLMConfigName)
+		if err != nil {
+			panic(err)
+		}
+		if llmConfig.ModelType != domain.LLMModelTypeMultiModalEmbedding {
+			panic(fmt.Sprintf("Ha3KnowledgeVectorConf.LLMConfigName %q must be a multi-modal embedding config", knowledgeConf.LLMConfigName))
+		}
+		log.Info(fmt.Sprintf("module=Ha3ChatRecall\tevent=knowledge_llm_config_loaded\tfeatureStore=%s\tllmConfig=%s\tmodel=%s\tmodelType=%s",
+			knowledgeConf.FeatureStoreName, knowledgeConf.LLMConfigName, llmConfig.Model, llmConfig.ModelType))
+		recall.knowledgeConf = &knowledgeConf
+		recall.knowledgeLLM = llmConfig
+	}
+	return recall
 }
 
 func (r *Ha3ChatRecall) GetCandidateItems(user *module.User, context *pairecctx.RecommendContext) []*module.Item {


### PR DESCRIPTION
## Summary

- add optional `Ha3KnowledgeVectorConf` under the existing chat recall configuration
- generate query embeddings through the configured Feature Store LLM configuration and run HA3/OpenSearch vector retrieval against the catalog knowledge index
- expose retrieved knowledge candidates to the existing AI shopping Planner and strictly validate selected candidate IDs before applying their catalog terms
- keep the existing AI shopping behavior unchanged when knowledge vector configuration is absent, and degrade to the existing Planner flow when online knowledge retrieval fails

## Why

The existing field-aware fallback can only search terms produced by the Planner. User wording that does not match the catalog vocabulary can therefore still produce zero or irrelevant results. This change grounds Planner product-type extraction in values retrieved from a knowledge index built from the actual product catalog.

This is a stacked PR on top of #225. It contains only the knowledge-vector increment; the field-aware fallback remains isolated in PR1.

## Implementation notes

- embeddings are generated with the Feature Store Go SDK using `FeatureStoreName` and `LLMConfigName`; vector dimension comes from the configured model
- knowledge search is enabled only when `Ha3KnowledgeVectorConf` is present
- `KnowledgeTypes` is required and limited to `category`, `categories`, `content`, `brand`, `tag`, and `title`
- the Planner may only select IDs returned by the current knowledge query; unknown or duplicate IDs are rejected
- selected candidate values are converted into existing `product_type_keywords`, so the product recall path stays small and reuses field-aware fallback

## Validation

- `git diff --check`
- `go test ./service/aishopping ./service/recall ./algorithm/aichat ./persist/fs ./recconf -run '^$'`
- `go vet ./service/aishopping ./service/recall ./algorithm/aichat ./persist/fs ./recconf`
- `go build ./...`
- 1,901-query PAI-REC integration run: 0 HTTP errors; Reply zero-return UV rate improved from 2.3964% to 1.5583%, HitRate@12 from 92.2300% to 93.0747%, and result precision from 83.1680% to 84.4035%

Known repository test issue: running the unfiltered `service/recall` test package still fails in the pre-existing `TestMultibizRecall` because it constructs `NewBeMultiBizRecall` with a nil configuration. The package compilation gate, vet, and full repository build pass.
