### PR TITLE
feat: support distinct in AI shopping OpenSearch recall

### DIFF
--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -395,6 +395,19 @@ type Ha3ChatRecallConfig struct {
 	TagsField       string
 	Analyzer        string
 	PriceField      string
+	DistinctConf    *Ha3ChatDistinctConfig
+}
+
+type Ha3ChatDistinctConfig struct {
+	Default *Ha3ChatDistinctRuleConfig
+}
+
+type Ha3ChatDistinctRuleConfig struct {
+	DistKey      string
+	DistCount    int
+	DistTimes    int
+	Reserved     *bool
+	MaxItemCount int
 }
 
 type Ha3KnowledgeVectorConfig struct {

--- a/service/recall/ha3_chat_distinct.go
+++ b/service/recall/ha3_chat_distinct.go
@@ -1,0 +1,57 @@
+package recall
+
+import (
+	"fmt"
+
+	"github.com/alibaba/pairec/v2/recconf"
+)
+
+func normalizeHa3ChatDistinctConfig(conf *recconf.Ha3ChatDistinctConfig) *recconf.Ha3ChatDistinctConfig {
+	if conf == nil {
+		return nil
+	}
+	if conf.Default == nil {
+		panic("Ha3ChatRecallConf.DistinctConf.Default is required")
+	}
+
+	rule := *conf.Default
+	if !validHa3FieldName(rule.DistKey) {
+		panic(fmt.Sprintf("Ha3ChatRecallConf.DistinctConf.Default.DistKey has invalid field name %q", rule.DistKey))
+	}
+	if rule.DistCount < 0 {
+		panic("Ha3ChatRecallConf.DistinctConf.Default.DistCount must not be negative")
+	}
+	if rule.DistCount == 0 {
+		rule.DistCount = 1
+	}
+	if rule.DistTimes < 0 {
+		panic("Ha3ChatRecallConf.DistinctConf.Default.DistTimes must not be negative")
+	}
+	if rule.DistTimes == 0 {
+		rule.DistTimes = 1
+	}
+	if rule.MaxItemCount < 0 {
+		panic("Ha3ChatRecallConf.DistinctConf.Default.MaxItemCount must not be negative")
+	}
+	reserved := true
+	if rule.Reserved != nil {
+		reserved = *rule.Reserved
+	}
+	rule.Reserved = &reserved
+
+	return &recconf.Ha3ChatDistinctConfig{Default: &rule}
+}
+
+func buildHa3ChatDistinctClause(conf *recconf.Ha3ChatDistinctConfig) map[string]interface{} {
+	rule := conf.Default
+	defaultRule := map[string]interface{}{
+		"dist_key":   rule.DistKey,
+		"dist_count": rule.DistCount,
+		"dist_times": rule.DistTimes,
+		"reserved":   *rule.Reserved,
+	}
+	if rule.MaxItemCount > 0 {
+		defaultRule["max_item_count"] = rule.MaxItemCount
+	}
+	return map[string]interface{}{"default": defaultRule}
+}

--- a/service/recall/ha3_chat_recall.go
+++ b/service/recall/ha3_chat_recall.go
@@ -74,6 +74,7 @@ func NewHa3ChatRecall(config recconf.RecallConfig) *Ha3ChatRecall {
 		}
 	}
 	validateHa3ChatFieldConfig(conf)
+	conf.DistinctConf = normalizeHa3ChatDistinctConfig(conf.DistinctConf)
 	if config.Ha3KnowledgeVectorConf != nil && !ha3ChatFieldAwareConfigured(conf) {
 		panic("Ha3KnowledgeVectorConf requires field-aware Ha3ChatRecallConf")
 	}
@@ -159,6 +160,9 @@ func (r *Ha3ChatRecall) searchField(ctx context.Context, field string, keywords 
 	}
 	if filterExpr != "" {
 		body["filter"] = filterExpr
+	}
+	if r.conf.DistinctConf != nil {
+		body["distinct"] = buildHa3ChatDistinctClause(r.conf.DistinctConf)
 	}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
@@ -280,9 +284,13 @@ func sanitizeSearchKeyword(keyword string) string {
 }
 
 func parseHa3ChatResponse(resp *ha3client.SearchResponseModel) (*SearchGoodsResult, error) {
-	total, items, _, err := decodeHa3ChatResponse(resp)
+	total, items, responseErrors, err := decodeHa3ChatResponse(resp)
 	if err != nil {
 		return nil, err
+	}
+	if hasHa3ResponseErrors(responseErrors) {
+		payload, _ := json.Marshal(responseErrors)
+		return nil, fmt.Errorf("ha3 search errors: %s", payload)
 	}
 	hits := make([]GoodsHit, 0, len(items))
 	for index, item := range items {


### PR DESCRIPTION
## What changed

- Add optional `Ha3ChatRecallConf.DistinctConf.Default` configuration.
- Validate and normalize `DistKey`, `DistCount`, `DistTimes`, `Reserved`, and `MaxItemCount`.
- Inject OpenSearch `distinct.default` in the shared search path used by primary recall and field-aware fallback.
- Surface OpenSearch response errors in the legacy response path instead of treating them as normal zero recall.

When `DistinctConf` is omitted, the request body is unchanged and distinct remains disabled.

## Why

AI shopping results need configurable category diversification across the full OpenSearch recall chain. The implementation is intentionally limited to the required `distinct.default` clause and does not change prompts, tool schemas, RRF, or local ranking.
