### PR TITLE
feat: support writing feature logs to FeatureDB via fs sdk direct write

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 require (
 	fortio.org/assert v1.2.1
 	github.com/alibabacloud-go/opensearch-util v1.0.1
-	github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260731011323-5c4e41560f3c
+	github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260824121457-40812bc7c232
 	github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260714015931-6e1064f3fe1a
 	github.com/aliyun/credentials-go v1.4.8
 	github.com/apache/calcite-avatica-go/v5 v5.0.0

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260716155729-936c
 github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260716155729-936cf179a999/go.mod h1:Fk/aeR8Le+tyDMWLevf+jEg0tkcvMmCJiN65yIdg0J0=
 github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260731011323-5c4e41560f3c h1:vEV3hdlbT/K6LZ2pkqUD4aBeFRdxoV6gtWMuKoPknSQ=
 github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260731011323-5c4e41560f3c/go.mod h1:Fk/aeR8Le+tyDMWLevf+jEg0tkcvMmCJiN65yIdg0J0=
+github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260824121457-40812bc7c232 h1:NbVQ6a9VTK6La9TOGHlFXE8ATEVzYUEeY7KdRuxFw4Q=
+github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260824121457-40812bc7c232/go.mod h1:Fk/aeR8Le+tyDMWLevf+jEg0tkcvMmCJiN65yIdg0J0=
 github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260714015931-6e1064f3fe1a h1:FuXOWqmoFfpGl5TM/H0bgDDNVTMNbfG5pIEp3eI17AA=
 github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260714015931-6e1064f3fe1a/go.mod h1:TjHkSEFlBAPhzp5sT5rheXSorgIdKxVh/2MVG2qHXmA=
 github.com/aliyun/aliyun-tablestore-go-sdk v1.7.7 h1:+d/mcgaxx1jaWtFN2WrBHy4XeM9IK5gmZvbbpVkhqHE=

--- a/log/feature_log/feature_log.go
+++ b/log/feature_log/feature_log.go
@@ -163,7 +163,7 @@ func getFeatureData(user *module.User, userFields string, items []*module.Item, 
 // per request. When logItems is enabled, all item infos are merged into one
 // record in the "items" field, otherwise item infos are not logged.
 func getFeatureStoreLogData(user *module.User, userFields string, items []*module.Item, itemFields string, logItems bool, context *context.RecommendContext) []map[string]interface{} {
-	requestTime := time.Now().Unix()
+	requestTime := time.Now().UnixMilli()
 
 	logMap := map[string]interface{}{
 		"request_id":   context.RecommendId,

--- a/log/feature_log/feature_log.go
+++ b/log/feature_log/feature_log.go
@@ -13,6 +13,8 @@ import (
 	"github.com/alibaba/pairec/v2/datasource/datahub"
 	"github.com/alibaba/pairec/v2/log"
 	"github.com/alibaba/pairec/v2/module"
+	"github.com/alibaba/pairec/v2/persist/fs"
+	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/domain"
 )
 
 var json = jsoniter.ConfigCompatibleWithStandardLibrary
@@ -38,7 +40,14 @@ func FeatureLog(user *module.User, items []*module.Item, context *context.Recomm
 		return
 	}
 
-	messages := getFeatureData(user, config.UserFeatures, items, config.ItemFeatures, config.SplitUserItemLogs, context)
+	var messages []map[string]interface{}
+	if config.OutputType == "featurestore" {
+		// for featurestore output, only one log is written per request,
+		// item infos are merged into one record when LogItems is enabled
+		messages = getFeatureStoreLogData(user, config.UserFeatures, items, config.ItemFeatures, config.LogItems, context)
+	} else {
+		messages = getFeatureData(user, config.UserFeatures, items, config.ItemFeatures, config.SplitUserItemLogs, context)
+	}
 
 	if len(messages) == 0 {
 		return
@@ -51,6 +60,23 @@ func FeatureLog(user *module.User, items []*module.Item, context *context.Recomm
 			return
 		}
 		go datahubApi.SendMessage(messages)
+	} else if config.OutputType == "featurestore" {
+		fsClient, err := fs.GetFeatureStoreClient(config.FeatureStoreName)
+		if err != nil {
+			log.Error(fmt.Sprintf("requestId=%s\tevent=FeatureLog\terr=%v", context.RecommendId, err))
+			return
+		}
+		featureView := fsClient.GetProject().GetFeatureView(config.FeatureStoreViewName)
+		if featureView == nil {
+			log.Error(fmt.Sprintf("requestId=%s\tevent=FeatureLog\terr=feature view not found, name:%s", context.RecommendId, config.FeatureStoreViewName))
+			return
+		}
+		// write feature logs to FeatureDB directly via fs sdk direct write interface
+		go func() {
+			if err := featureView.WriteFeatures(messages, domain.WithDirect()); err != nil {
+				log.Error(fmt.Sprintf("requestId=%s\tevent=FeatureLog\terr=%v", context.RecommendId, err))
+			}
+		}()
 	}
 }
 
@@ -130,6 +156,53 @@ func getFeatureData(user *module.User, userFields string, items []*module.Item, 
 		messages = append(messages, logMap)
 	}
 	return messages
+}
+
+// getFeatureStoreLogData builds a single feature log record for featurestore output.
+// Unlike getFeatureData which logs one record per item, this returns only one log
+// per request. When logItems is enabled, all item infos are merged into one
+// record in the "items" field, otherwise item infos are not logged.
+func getFeatureStoreLogData(user *module.User, userFields string, items []*module.Item, itemFields string, logItems bool, context *context.RecommendContext) []map[string]interface{} {
+	requestTime := time.Now().Unix()
+
+	logMap := map[string]interface{}{
+		"request_id":   context.RecommendId,
+		"scene_id":     context.GetParameter("scene"),
+		"user_id":      string(user.Id),
+		"request_time": requestTime,
+	}
+
+	if context.ExperimentResult != nil {
+		logMap["exp_id"] = context.ExperimentResult.GetExpId()
+	}
+
+	userFeatures := getUserFeatures(user, userFields)
+	if len(userFeatures) > 0 {
+		data, err := json.Marshal(userFeatures)
+		if err != nil {
+			log.Error(fmt.Sprintf("requestId=%s\tevent=FeatureLog\terr=%v", context.RecommendId, err))
+		} else {
+			logMap["user_features"] = string(data)
+		}
+	}
+
+	if logItems {
+		itemRecords := make([]map[string]interface{}, 0, len(items))
+		for i, item := range items {
+			itemMap := getItemFeatures(item, itemFields)
+			itemMap["item_id"] = string(item.Id)
+			itemMap["position"] = strconv.Itoa(i + 1)
+			itemRecords = append(itemRecords, itemMap)
+		}
+		data, err := json.Marshal(itemRecords)
+		if err != nil {
+			log.Error(fmt.Sprintf("requestId=%s\tevent=FeatureLog\terr=%v", context.RecommendId, err))
+		} else {
+			logMap["items"] = string(data)
+		}
+	}
+
+	return []map[string]interface{}{logMap}
 }
 
 func getUserFeatures(user *module.User, userFields string) (result map[string]interface{}) {

--- a/log/feature_log/feature_log.go
+++ b/log/feature_log/feature_log.go
@@ -3,6 +3,7 @@ package feature_log
 import (
 	"fmt"
 	"math/rand"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -73,6 +74,14 @@ func FeatureLog(user *module.User, items []*module.Item, context *context.Recomm
 		}
 		// write feature logs to FeatureDB directly via fs sdk direct write interface
 		go func() {
+			// the sdk serializes the records and does the http call inside this
+			// goroutine, recover so a panic in it can not take down the process
+			defer func() {
+				if err := recover(); err != nil {
+					stack := string(debug.Stack())
+					log.Error(fmt.Sprintf("requestId=%s\tevent=FeatureLog\terr=%v\tstack=%s", context.RecommendId, err, strings.ReplaceAll(stack, "\n", "\t")))
+				}
+			}()
 			if err := featureView.WriteFeatures(messages, domain.WithDirect()); err != nil {
 				log.Error(fmt.Sprintf("requestId=%s\tevent=FeatureLog\terr=%v", context.RecommendId, err))
 			}

--- a/log/feature_log/feature_log.go
+++ b/log/feature_log/feature_log.go
@@ -163,7 +163,7 @@ func getFeatureData(user *module.User, userFields string, items []*module.Item, 
 // per request. When logItems is enabled, all item infos are merged into one
 // record in the "items" field, otherwise item infos are not logged.
 func getFeatureStoreLogData(user *module.User, userFields string, items []*module.Item, itemFields string, logItems bool, context *context.RecommendContext) []map[string]interface{} {
-	requestTime := time.Now().UnixMilli()
+	requestTime := time.Now().Unix()
 
 	logMap := map[string]interface{}{
 		"request_id":   context.RecommendId,

--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -1094,6 +1094,17 @@ type FeatureLogConfig struct {
 	UserFeatures string
 	ItemFeatures string
 
+	// FeatureStoreName is required when OutputType=featurestore,
+	// it is the name of FeatureStoreConfs
+	FeatureStoreName string
+	// FeatureStoreViewName is required when OutputType=featurestore,
+	// feature logs are written to this feature view of FeatureDB via fs sdk direct write
+	FeatureStoreViewName string
+	// LogItems is only used when OutputType=featurestore,
+	// when enabled, all item infos are merged into one record in the single feature log,
+	// default is false which means item infos are not logged
+	LogItems bool
+
 	SplitUserItemLogs bool
 }
 

--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -1003,6 +1003,10 @@ type CallBackConfig struct {
 	ItemSize        int
 	ItemSizeRate    int
 	UseUserFeatures bool
+	// DebugLevel is the debug_level sent to the easyrec processor, it defaults
+	// to 3 when not set. Set it to 6 to let the processor write the feature log
+	// on its own side, in that case DataSource can be left empty.
+	DebugLevel int
 }
 type EmbeddingConfig struct {
 	DataSource DataSourceConfig

--- a/service/call_back_service.go
+++ b/service/call_back_service.go
@@ -23,6 +23,11 @@ import (
 	"github.com/alibaba/pairec/v2/utils"
 )
 
+// processorWriteCallbackLogDebugLevel is the debug_level that makes the easyrec
+// processor write the callback feature log on its own side. A request using it
+// must reach the processor, otherwise no log is produced at all.
+const processorWriteCallbackLogDebugLevel = 6
+
 type CallBackService struct {
 	recallService      *RecallService
 	featureService     *feature.FeatureService
@@ -175,6 +180,9 @@ func (r *CallBackService) Rank(context *context.RecommendContext) {
 
 	var algoData rank.IAlgoData
 	debugLevel := 3
+	if callBackConfig.DebugLevel > 0 {
+		debugLevel = callBackConfig.DebugLevel
+	}
 
 	writeRawFeatrues := false
 	if callBackConfig.RawFeatures && callBackConfig.RawFeaturesRate > 0 {
@@ -184,11 +192,16 @@ func (r *CallBackService) Rank(context *context.RecommendContext) {
 		}
 	}
 
+	// carry the request id in the pb meta data, so the processor side log can be
+	// joined back to this callback request, same as the rank and recall paths do
+	meta := map[string]string{"request_id": context.RecommendId}
 	if algoGenerator.HasFeatures() {
-		if context.Debug {
-			algoData = algoGenerator.GeneratorAlgoDataDebugWithLevel(2, nil)
+		// the processor writes the log itself at this level, so it has to be sent
+		// through even for a debug request
+		if context.Debug && debugLevel != processorWriteCallbackLogDebugLevel {
+			algoData = algoGenerator.GeneratorAlgoDataDebugWithLevel(2, meta)
 		} else {
-			algoData = algoGenerator.GeneratorAlgoDataDebugWithLevel(debugLevel, nil)
+			algoData = algoGenerator.GeneratorAlgoDataDebugWithLevel(debugLevel, meta)
 		}
 	}
 

--- a/service/feature/op.go
+++ b/service/feature/op.go
@@ -146,8 +146,9 @@ func (op ComposeFeatureOp) ItemTransOp(featureName string, source string, remove
 // user_features column written by feature log.
 //
 // FeatureName is not used by this op, the expanded feature names come from the
-// keys of the JSON object. Note that the JSON round trip degrades every number
-// to float64, so integer valued features are restored as float64.
+// keys of the JSON object. Values are restored by their JSON type, so an integer
+// stays an integer and a list or object becomes the concrete slice or map type
+// the easyrec request builder has a case for, see convertJsonValue.
 //
 // RemoveFeatureSource is ignored when FeatureStore is item and FeatureSource
 // points at a user property, because that single property is the source shared
@@ -168,8 +169,8 @@ func (op ExpandJsonFeatureOp) UserTransOp(featureName string, source string, rem
 		return
 	}
 
-	properties := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(value), &properties); err != nil {
+	properties, err := unmarshalJsonProperties(value)
+	if err != nil {
 		log.Error(fmt.Sprintf("requestId=%s\tmodule=ExpandJsonFeatureOp\tsource=%s\terror=%v", op.getRequestId(context), comms[1], err))
 		return
 	}
@@ -199,8 +200,8 @@ func (op ExpandJsonFeatureOp) ItemTransOp(featureName string, source string, rem
 		return
 	}
 
-	properties := make(map[string]interface{})
-	if err := json.Unmarshal([]byte(value), &properties); err != nil {
+	properties, err := unmarshalJsonProperties(value)
+	if err != nil {
 		log.Error(fmt.Sprintf("requestId=%s\tmodule=ExpandJsonFeatureOp\tsource=%s\terror=%v", op.getRequestId(context), comms[1], err))
 		return
 	}
@@ -212,6 +213,244 @@ func (op ExpandJsonFeatureOp) ItemTransOp(featureName string, source string, rem
 		item.DeleteProperty(comms[1])
 	}
 	item.AddProperties(properties)
+}
+
+// unmarshalJsonProperties decodes a JSON object string into properties, keeping
+// the numbers as json.Number. The default decoding turns every number into a
+// float64, which loses precision above 2^53 and also changes the feature type
+// that is finally sent to the processor, so a snapshot would not restore the
+// features the model was scored with.
+func unmarshalJsonProperties(value string) (map[string]interface{}, error) {
+	decoder := json.NewDecoder(strings.NewReader(value))
+	decoder.UseNumber()
+
+	properties := make(map[string]interface{})
+	if err := decoder.Decode(&properties); err != nil {
+		return nil, err
+	}
+	for k, v := range properties {
+		properties[k] = convertJsonValue(v)
+	}
+	return properties, nil
+}
+
+// convertJsonValue restores the Go type of a value decoded with json.Number.
+//
+// The restoration is driven by the json type of the value, because a json round
+// trip keeps the string and number distinction: a []string is written back as a
+// list of quoted elements while a []int64 is written back as a list of bare
+// numbers. Restoring by that distinction keeps the feature type close to the one
+// the model was scored with, which a blanket conversion to string would not.
+func convertJsonValue(value interface{}) interface{} {
+	switch v := value.(type) {
+	case json.Number:
+		return convertJsonNumber(v)
+	case []interface{}:
+		return convertJsonList(v)
+	case map[string]interface{}:
+		return convertJsonMap(v)
+	default:
+		return value
+	}
+}
+
+// convertJsonNumber restores the numeric type of a json.Number, the same way
+// web.FeaturesMap does for the features carried in a request body.
+func convertJsonNumber(number json.Number) interface{} {
+	if i64, err := number.Int64(); err == nil {
+		return int(i64)
+	}
+	if f64, err := number.Float64(); err == nil {
+		return f64
+	}
+	return number.String()
+}
+
+// convertJsonList restores a list to the concrete slice type matching the json
+// type of its elements, so the easyrec request builder has a case for it. A list
+// the builder has no type for only gets its elements restored one by one.
+func convertJsonList(list []interface{}) interface{} {
+	if len(list) == 0 {
+		// an empty list gives no hint about its element type
+		return list
+	}
+
+	allString, allNumber, allList := true, true, true
+	integral, numeric := true, true
+	for _, elem := range list {
+		switch v := elem.(type) {
+		case string:
+			allNumber, allList = false, false
+		case json.Number:
+			allString, allList = false, false
+			if _, err := v.Int64(); err != nil {
+				integral = false
+				if _, err := v.Float64(); err != nil {
+					numeric = false
+				}
+			}
+		case []interface{}:
+			allString, allNumber = false, false
+		default:
+			allString, allNumber, allList = false, false, false
+		}
+	}
+
+	switch {
+	case allString:
+		values := make([]string, len(list))
+		for i, elem := range list {
+			values[i] = elem.(string)
+		}
+		return values
+	case allNumber && integral:
+		values := make([]int, len(list))
+		for i, elem := range list {
+			i64, _ := elem.(json.Number).Int64()
+			values[i] = int(i64)
+		}
+		return values
+	case allNumber && numeric:
+		values := make([]float64, len(list))
+		for i, elem := range list {
+			f64, _ := elem.(json.Number).Float64()
+			values[i] = f64
+		}
+		return values
+	case allList:
+		return convertJsonNestedList(list)
+	}
+
+	for i, elem := range list {
+		list[i] = convertJsonValue(elem)
+	}
+	return list
+}
+
+// convertJsonMap restores a json object to the concrete map type matching the
+// json type of its values, so the easyrec request builder has a case for it.
+//
+// A json object always has string keys, so the key type of the original feature
+// is not recoverable: a map[int64]string and a map[string]string look exactly the
+// same once written. The keys are restored as strings, which turns a LongStringMap
+// into a StringStringMap. That is accepted, because the builder has no case for
+// map[string]interface{} at all, so the alternative is dropping the feature.
+//
+// An integral value gives a map[string]int64 and not a map[string]int, because
+// the builder casts a map[string]int down to int32 without a range check.
+func convertJsonMap(object map[string]interface{}) interface{} {
+	if len(object) == 0 {
+		// an empty object gives no hint about its value type
+		return object
+	}
+
+	allString, allNumber := true, true
+	integral, numeric := true, true
+	for _, elem := range object {
+		switch v := elem.(type) {
+		case string:
+			allNumber = false
+		case json.Number:
+			allString = false
+			if _, err := v.Int64(); err != nil {
+				integral = false
+				if _, err := v.Float64(); err != nil {
+					numeric = false
+				}
+			}
+		default:
+			allString, allNumber = false, false
+		}
+	}
+
+	switch {
+	case allString:
+		values := make(map[string]string, len(object))
+		for key, elem := range object {
+			values[key] = elem.(string)
+		}
+		return values
+	case allNumber && integral:
+		values := make(map[string]int64, len(object))
+		for key, elem := range object {
+			values[key], _ = elem.(json.Number).Int64()
+		}
+		return values
+	case allNumber && numeric:
+		values := make(map[string]float64, len(object))
+		for key, elem := range object {
+			values[key], _ = elem.(json.Number).Float64()
+		}
+		return values
+	}
+
+	for key, elem := range object {
+		object[key] = convertJsonValue(elem)
+	}
+	return object
+}
+
+// convertJsonNestedList restores a list of lists, the builder carries those as
+// [][]string, [][]int64 or [][]float64.
+func convertJsonNestedList(list []interface{}) interface{} {
+	allString, allNumber := true, true
+	integral, numeric := true, true
+	for _, elem := range list {
+		for _, inner := range elem.([]interface{}) {
+			switch v := inner.(type) {
+			case string:
+				allNumber = false
+			case json.Number:
+				allString = false
+				if _, err := v.Int64(); err != nil {
+					integral = false
+					if _, err := v.Float64(); err != nil {
+						numeric = false
+					}
+				}
+			default:
+				allString, allNumber = false, false
+			}
+		}
+	}
+
+	switch {
+	case allString:
+		values := make([][]string, len(list))
+		for i, elem := range list {
+			inner := elem.([]interface{})
+			values[i] = make([]string, len(inner))
+			for j, v := range inner {
+				values[i][j] = v.(string)
+			}
+		}
+		return values
+	case allNumber && integral:
+		values := make([][]int64, len(list))
+		for i, elem := range list {
+			inner := elem.([]interface{})
+			values[i] = make([]int64, len(inner))
+			for j, v := range inner {
+				values[i][j], _ = v.(json.Number).Int64()
+			}
+		}
+		return values
+	case allNumber && numeric:
+		values := make([][]float64, len(list))
+		for i, elem := range list {
+			inner := elem.([]interface{})
+			values[i] = make([]float64, len(inner))
+			for j, v := range inner {
+				values[i][j], _ = v.(json.Number).Float64()
+			}
+		}
+		return values
+	}
+
+	for i, elem := range list {
+		list[i] = convertJsonValue(elem)
+	}
+	return list
 }
 
 // ContextFeatureOp add context feature to user

--- a/service/feature/op.go
+++ b/service/feature/op.go
@@ -148,6 +148,10 @@ func (op ComposeFeatureOp) ItemTransOp(featureName string, source string, remove
 // FeatureName is not used by this op, the expanded feature names come from the
 // keys of the JSON object. Note that the JSON round trip degrades every number
 // to float64, so integer valued features are restored as float64.
+//
+// RemoveFeatureSource is ignored when FeatureStore is item and FeatureSource
+// points at a user property, because that single property is the source shared
+// by every item, same as ComposeFeatureOp does.
 type ExpandJsonFeatureOp struct {
 	featureOp
 }
@@ -201,12 +205,11 @@ func (op ExpandJsonFeatureOp) ItemTransOp(featureName string, source string, rem
 		return
 	}
 
-	if remove {
-		if comms[0] == SOURCE_USER {
-			user.DeleteProperty(comms[1])
-		} else {
-			item.DeleteProperty(comms[1])
-		}
+	// only a source on the item itself is removed. FeatureTran calls ItemTransOp
+	// once per item, so removing a user property while handling the first item
+	// would leave the remaining items with an empty source to expand.
+	if remove && comms[0] != SOURCE_USER {
+		item.DeleteProperty(comms[1])
 	}
 	item.AddProperties(properties)
 }

--- a/service/feature/op.go
+++ b/service/feature/op.go
@@ -1,10 +1,12 @@
 package feature
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/alibaba/pairec/v2/context"
+	"github.com/alibaba/pairec/v2/log"
 	"github.com/alibaba/pairec/v2/module"
 )
 
@@ -26,6 +28,8 @@ func NewFeatureOp(t string) FeatureOp {
 		return CreateNewFeatureOp{}
 	} else if t == "context_feature" {
 		return ContextFeatureOp{}
+	} else if t == "expand_json_feature" {
+		return ExpandJsonFeatureOp{}
 	}
 
 	panic(fmt.Sprintf("not find feature type:%s", t))
@@ -134,6 +138,77 @@ func (op ComposeFeatureOp) ItemTransOp(featureName string, source string, remove
 	}
 
 	item.AddProperty(featureName, featureValue)
+}
+
+// ExpandJsonFeatureOp expands a property holding a JSON object string into
+// separate properties, one per key of that object. It is used to restore a
+// feature snapshot that is stored as a single JSON string column, such as the
+// user_features column written by feature log.
+//
+// FeatureName is not used by this op, the expanded feature names come from the
+// keys of the JSON object. Note that the JSON round trip degrades every number
+// to float64, so integer valued features are restored as float64.
+type ExpandJsonFeatureOp struct {
+	featureOp
+}
+
+func (op ExpandJsonFeatureOp) UserTransOp(featureName string, source string, remove bool, normalizer Normalizer, user *module.User, context *context.RecommendContext) {
+	comms := strings.Split(source, ":")
+	if len(comms) < 2 {
+		log.Error(fmt.Sprintf("requestId=%s\tmodule=ExpandJsonFeatureOp\terror=featureSource error(%s)", op.getRequestId(context), source))
+		return
+	}
+
+	value := user.StringProperty(comms[1])
+	if value == "" {
+		return
+	}
+
+	properties := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(value), &properties); err != nil {
+		log.Error(fmt.Sprintf("requestId=%s\tmodule=ExpandJsonFeatureOp\tsource=%s\terror=%v", op.getRequestId(context), comms[1], err))
+		return
+	}
+
+	// remove the source before expanding, so a key of the same name inside the
+	// JSON object is kept instead of being deleted right after being added
+	if remove {
+		user.DeleteProperty(comms[1])
+	}
+	user.AddProperties(properties)
+}
+
+func (op ExpandJsonFeatureOp) ItemTransOp(featureName string, source string, remove bool, normalizer Normalizer, user *module.User, item *module.Item, context *context.RecommendContext) {
+	comms := strings.Split(source, ":")
+	if len(comms) < 2 {
+		log.Error(fmt.Sprintf("requestId=%s\tmodule=ExpandJsonFeatureOp\terror=featureSource error(%s)", op.getRequestId(context), source))
+		return
+	}
+
+	var value string
+	if comms[0] == SOURCE_USER {
+		value = user.StringProperty(comms[1])
+	} else {
+		value = item.StringProperty(comms[1])
+	}
+	if value == "" {
+		return
+	}
+
+	properties := make(map[string]interface{})
+	if err := json.Unmarshal([]byte(value), &properties); err != nil {
+		log.Error(fmt.Sprintf("requestId=%s\tmodule=ExpandJsonFeatureOp\tsource=%s\terror=%v", op.getRequestId(context), comms[1], err))
+		return
+	}
+
+	if remove {
+		if comms[0] == SOURCE_USER {
+			user.DeleteProperty(comms[1])
+		} else {
+			item.DeleteProperty(comms[1])
+		}
+	}
+	item.AddProperties(properties)
 }
 
 // ContextFeatureOp add context feature to user

--- a/service/feature/op_test.go
+++ b/service/feature/op_test.go
@@ -155,3 +155,105 @@ func TestNewFeatureWithExpressionFeatureOp(t *testing.T) {
 	})
 
 }
+
+func TestExpandJsonFeatureOp(t *testing.T) {
+	userConf := func(remove bool) recconf.FeatureLoadConfig {
+		conf := recconf.FeatureLoadConfig{}
+		conf.Features = append(conf.Features, recconf.FeatureConfig{
+			FeatureType:         "expand_json_feature",
+			FeatureStore:        "user",
+			FeatureSource:       "user:user_features",
+			RemoveFeatureSource: remove,
+		})
+		return conf
+	}
+
+	t.Run("expand user snapshot and remove source", func(t *testing.T) {
+		user := module.NewUser("user1")
+		user.AddProperties(map[string]interface{}{
+			"user_features": `{"gender":"male","age":30,"score":1.5,"tags":["a","b"]}`,
+		})
+
+		feature := LoadWithConfig(userConf(true))
+		feature.LoadFeatures(user, nil, context.NewRecommendContext())
+
+		assert.Equal(t, user.StringProperty("gender"), "male")
+		// every json number is restored as float64
+		assert.Equal(t, user.GetProperty("age"), float64(30))
+		assert.Equal(t, user.GetProperty("score"), float64(1.5))
+		assert.Equal(t, user.GetProperty("tags"), []interface{}{"a", "b"})
+		// RemoveFeatureSource drops the json column itself
+		assert.Equal(t, user.GetProperty("user_features"), nil)
+	})
+
+	t.Run("keep source when RemoveFeatureSource is false", func(t *testing.T) {
+		user := module.NewUser("user1")
+		user.AddProperties(map[string]interface{}{
+			"user_features": `{"gender":"female"}`,
+		})
+
+		feature := LoadWithConfig(userConf(false))
+		feature.LoadFeatures(user, nil, context.NewRecommendContext())
+
+		assert.Equal(t, user.StringProperty("gender"), "female")
+		assert.Equal(t, user.StringProperty("user_features"), `{"gender":"female"}`)
+	})
+
+	t.Run("expanded value overrides existing property", func(t *testing.T) {
+		user := module.NewUser("user1")
+		user.AddProperties(map[string]interface{}{
+			"gender":        "unknown",
+			"user_features": `{"gender":"male"}`,
+		})
+
+		feature := LoadWithConfig(userConf(true))
+		feature.LoadFeatures(user, nil, context.NewRecommendContext())
+
+		assert.Equal(t, user.StringProperty("gender"), "male")
+	})
+
+	t.Run("invalid json leaves properties untouched", func(t *testing.T) {
+		user := module.NewUser("user1")
+		user.AddProperties(map[string]interface{}{
+			"user_features": `not a json`,
+		})
+
+		feature := LoadWithConfig(userConf(true))
+		feature.LoadFeatures(user, nil, context.NewRecommendContext())
+
+		// source is kept so the failure stays diagnosable
+		assert.Equal(t, user.StringProperty("user_features"), `not a json`)
+	})
+
+	t.Run("missing source is a no-op", func(t *testing.T) {
+		user := module.NewUser("user1")
+		user.AddProperties(map[string]interface{}{"gender": "male"})
+
+		feature := LoadWithConfig(userConf(true))
+		feature.LoadFeatures(user, nil, context.NewRecommendContext())
+
+		assert.Equal(t, user.StringProperty("gender"), "male")
+		assert.Equal(t, user.GetProperty("user_features"), nil)
+	})
+
+	t.Run("expand item snapshot", func(t *testing.T) {
+		item := module.NewItem("123")
+		item.AddProperty("item_features", `{"category":"movie","price":9.9}`)
+		user := module.NewUser("user1")
+
+		conf := recconf.FeatureLoadConfig{}
+		conf.Features = append(conf.Features, recconf.FeatureConfig{
+			FeatureType:         "expand_json_feature",
+			FeatureStore:        "item",
+			FeatureSource:       "item:item_features",
+			RemoveFeatureSource: true,
+		})
+
+		feature := LoadWithConfig(conf)
+		feature.LoadFeatures(user, []*module.Item{item}, context.NewRecommendContext())
+
+		assert.Equal(t, item.StringProperty("category"), "movie")
+		assert.Equal(t, item.GetProperty("price"), float64(9.9))
+		assert.Equal(t, item.GetProperty("item_features"), nil)
+	})
+}

--- a/service/feature/op_test.go
+++ b/service/feature/op_test.go
@@ -256,4 +256,29 @@ func TestExpandJsonFeatureOp(t *testing.T) {
 		assert.Equal(t, item.GetProperty("price"), float64(9.9))
 		assert.Equal(t, item.GetProperty("item_features"), nil)
 	})
+
+	t.Run("expand user snapshot to every item", func(t *testing.T) {
+		user := module.NewUser("user1")
+		user.AddProperty("user_features", `{"gender":"male","age":30}`)
+		items := []*module.Item{module.NewItem("1"), module.NewItem("2"), module.NewItem("3")}
+
+		conf := recconf.FeatureLoadConfig{}
+		conf.Features = append(conf.Features, recconf.FeatureConfig{
+			FeatureType:         "expand_json_feature",
+			FeatureStore:        "item",
+			FeatureSource:       "user:user_features",
+			RemoveFeatureSource: true,
+		})
+
+		feature := LoadWithConfig(conf)
+		feature.LoadFeatures(user, items, context.NewRecommendContext())
+
+		// the user property is shared by every item, so all of them are expanded
+		// and RemoveFeatureSource does not drop it after the first item
+		for _, item := range items {
+			assert.Equal(t, item.StringProperty("gender"), "male")
+			assert.Equal(t, item.GetProperty("age"), float64(30))
+		}
+		assert.Equal(t, user.StringProperty("user_features"), `{"gender":"male","age":30}`)
+	})
 }

--- a/service/feature/op_test.go
+++ b/service/feature/op_test.go
@@ -178,10 +178,10 @@ func TestExpandJsonFeatureOp(t *testing.T) {
 		feature.LoadFeatures(user, nil, context.NewRecommendContext())
 
 		assert.Equal(t, user.StringProperty("gender"), "male")
-		// every json number is restored as float64
-		assert.Equal(t, user.GetProperty("age"), float64(30))
+		// an integer keeps an integer type, only a real decimal becomes a float64
+		assert.Equal(t, user.GetProperty("age"), 30)
 		assert.Equal(t, user.GetProperty("score"), float64(1.5))
-		assert.Equal(t, user.GetProperty("tags"), []interface{}{"a", "b"})
+		assert.Equal(t, user.GetProperty("tags"), []string{"a", "b"})
 		// RemoveFeatureSource drops the json column itself
 		assert.Equal(t, user.GetProperty("user_features"), nil)
 	})
@@ -277,8 +277,59 @@ func TestExpandJsonFeatureOp(t *testing.T) {
 		// and RemoveFeatureSource does not drop it after the first item
 		for _, item := range items {
 			assert.Equal(t, item.StringProperty("gender"), "male")
-			assert.Equal(t, item.GetProperty("age"), float64(30))
+			assert.Equal(t, item.GetProperty("age"), 30)
 		}
 		assert.Equal(t, user.StringProperty("user_features"), `{"gender":"male","age":30}`)
+	})
+
+	t.Run("keep the precision of an id beyond the float64 mantissa", func(t *testing.T) {
+		user := module.NewUser("user1")
+		user.AddProperty("user_features", `{"uid":9007199254740993,"big_id":1234567890123456789}`)
+
+		feature := LoadWithConfig(userConf(true))
+		feature.LoadFeatures(user, nil, context.NewRecommendContext())
+
+		// both values are above 2^53, a float64 round trip would alter them
+		assert.Equal(t, user.GetProperty("uid"), 9007199254740993)
+		assert.Equal(t, user.GetProperty("big_id"), 1234567890123456789)
+	})
+
+	t.Run("restore list features by their json element type", func(t *testing.T) {
+		user := module.NewUser("user1")
+		user.AddProperty("user_features", `{"tags":["a","b"],"ids":["101","102"],"seq":[101,102],"scores":[1.5,2.5],"nested":[["a"],["b","c"]],"nested_num":[[1.5],[2.5]],"mixed":[1,"a"],"empty":[]}`)
+
+		feature := LoadWithConfig(userConf(true))
+		feature.LoadFeatures(user, nil, context.NewRecommendContext())
+
+		// a quoted element stays a string even when it holds only digits, which is
+		// what keeps a []string snapshot from turning into a numeric list
+		assert.Equal(t, user.GetProperty("tags"), []string{"a", "b"})
+		assert.Equal(t, user.GetProperty("ids"), []string{"101", "102"})
+		// a bare number becomes a typed numeric list the request builder carries
+		assert.Equal(t, user.GetProperty("seq"), []int{101, 102})
+		assert.Equal(t, user.GetProperty("scores"), []float64{1.5, 2.5})
+		assert.Equal(t, user.GetProperty("nested"), [][]string{{"a"}, {"b", "c"}})
+		assert.Equal(t, user.GetProperty("nested_num"), [][]float64{{1.5}, {2.5}})
+		// the builder has no type for these two, only the elements are restored
+		assert.Equal(t, user.GetProperty("mixed"), []interface{}{1, "a"})
+		assert.Equal(t, user.GetProperty("empty"), []interface{}{})
+	})
+
+	t.Run("restore map features by their json value type", func(t *testing.T) {
+		user := module.NewUser("user1")
+		user.AddProperty("user_features", `{"cate":{"a":"x","b":"y"},"cnt":{"a":1,"b":9007199254740993},"rate":{"a":1.5},"mixed":{"a":1,"b":"x"},"empty":{},"deep":{"a":{"b":1}}}`)
+
+		feature := LoadWithConfig(userConf(true))
+		feature.LoadFeatures(user, nil, context.NewRecommendContext())
+
+		// the json object keys are restored as strings, the value type decides the map type
+		assert.Equal(t, user.GetProperty("cate"), map[string]string{"a": "x", "b": "y"})
+		// int64 and not int, the builder casts a map[string]int down to int32 unchecked
+		assert.Equal(t, user.GetProperty("cnt"), map[string]int64{"a": 1, "b": 9007199254740993})
+		assert.Equal(t, user.GetProperty("rate"), map[string]float64{"a": 1.5})
+		// the builder has no type for these, only the values are restored
+		assert.Equal(t, user.GetProperty("mixed"), map[string]interface{}{"a": 1, "b": "x"})
+		assert.Equal(t, user.GetProperty("empty"), map[string]interface{}{})
+		assert.Equal(t, user.GetProperty("deep"), map[string]interface{}{"a": map[string]int64{"b": 1}})
 	})
 }

--- a/web/callback_controller.go
+++ b/web/callback_controller.go
@@ -138,6 +138,9 @@ func (c *CallBackController) doCallbackLog() {
 
 	userId := module.UID(c.param.Uid)
 	user := module.NewUserWithContext(userId, c.context)
+	// expose request_id as a user property, so a feature dao can use it as the
+	// lookup key to restore the feature snapshot written by feature log
+	user.AddProperty("request_id", c.param.RequestId)
 	callBackService := service.NewCallBackService()
 	callBackService.User = user
 	callBackService.LoadUserFeatures(c.context)
@@ -180,7 +183,7 @@ func (c *CallBackController) doCallbackLog() {
 	log["request_id"] = c.param.RequestId
 	log["scene"] = c.param.SceneId
 	log["request_time"] = currTime.Unix()
-	userFeaturesData, _ := json.Marshal(callBackService.User.MakeUserFeatures())
+	userFeaturesData, _ := json.Marshal(callBackService.User.MakeUserFeatures2())
 	log["user_features"] = string(userFeaturesData)
 	log["user_id"] = string(callBackService.User.Id)
 	for k, v := range c.param.RequestInfo {


### PR DESCRIPTION
## Summary
- Add `featurestore` output type to `FeatureLogConfs`: feature logs are written to FeatureDB directly via the fs sdk direct write interface (`FeatureView.WriteFeatures` with `domain.WithDirect()`)
- For featurestore output, only one log record is written per request (keyed by user/request level); item infos are not logged by default, and can be merged into a single record via the new `LogItems` switch
- New config fields in `FeatureLogConfig`: `FeatureStoreName`, `FeatureStoreViewName`, `LogItems`
- The existing datahub output path is unchanged

## Configuration Example
```json
{
  "FeatureLogConfs": {
    "": {
      "OutputType": "featurestore",
      "Rate": 100,
      "FeatureStoreName": "fs_instance_name",
      "FeatureStoreViewName": "feature_log_view",
      "LogItems": false,
      "UserFeatures": "*",
      "ItemFeatures": ""
    }
  }
}
```

## Test Plan
- [x] go build ./...
- [x] go vet ./log/... ./recconf/...
- [x] go test ./recconf/...