### PR TITLE
feat: support EAS-driven vector recall versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	fortio.org/assert v1.2.1
 	github.com/alibabacloud-go/opensearch-util v1.0.1
 	github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260731011323-5c4e41560f3c
-	github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260714015931-6e1064f3fe1a
+	github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260820092810-95aabe924556
 	github.com/aliyun/credentials-go v1.4.8
 	github.com/apache/calcite-avatica-go/v5 v5.0.0
 	github.com/bruceding/go-antlr-valuate v0.0.4

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260731011323-5c4e
 github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2 v2.4.1-0.20260731011323-5c4e41560f3c/go.mod h1:Fk/aeR8Le+tyDMWLevf+jEg0tkcvMmCJiN65yIdg0J0=
 github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260714015931-6e1064f3fe1a h1:FuXOWqmoFfpGl5TM/H0bgDDNVTMNbfG5pIEp3eI17AA=
 github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260714015931-6e1064f3fe1a/go.mod h1:TjHkSEFlBAPhzp5sT5rheXSorgIdKxVh/2MVG2qHXmA=
+github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260820092810-95aabe924556 h1:Ph67TMwwuV6QFwIHyPkgpd5Fz8/zsGmEzE07tfOczRw=
+github.com/aliyun/aliyun-pairec-config-go-sdk/v2 v2.1.3-0.20260820092810-95aabe924556/go.mod h1:TjHkSEFlBAPhzp5sT5rheXSorgIdKxVh/2MVG2qHXmA=
 github.com/aliyun/aliyun-tablestore-go-sdk v1.7.7 h1:+d/mcgaxx1jaWtFN2WrBHy4XeM9IK5gmZvbbpVkhqHE=
 github.com/aliyun/aliyun-tablestore-go-sdk v1.7.7/go.mod h1:mZCxM44kLKLY5ci+0j6bJb0DG8PNQ5Mn40Y0bbYOhpE=
 github.com/aliyun/credentials-go v1.1.2/go.mod h1:ozcZaMR5kLM7pwtCMEpVmQ242suV6qTJya2bDq4X1Tw=

--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -445,14 +445,16 @@ type RecallEngineParam struct {
 	UserRealtimeEmbeddingTrigger UserRealtimeEmbeddingTriggerConfig // get user feature and invoke eas model, get item embedding sink to be
 	UserEmbeddingO2OTrigger      UserEmbeddingO2OTriggerConfig
 
-	ItemIdName      string
-	TriggerIdName   string
-	RecallTableName string
-	DiversityParam  string
-	CustomParams    map[string]interface{}
-	TriggerLimit    int
-	Timeout         int          // per-way recall timeout in milliseconds, 0 means no per-way timeout
-	Item2XConf      Item2XConfig // aggregate item triggers to item property(x) triggers, empty XKey means disabled
+	ItemIdName             string
+	TriggerIdName          string
+	RecallTableName        string
+	DiversityParam         string
+	CustomParams           map[string]interface{}
+	TriggerLimit           int
+	Timeout                int          // per-way recall timeout in milliseconds, 0 means no per-way timeout
+	VersionId              string       // item vector table version
+	UserEmbeddingVersionId string       // user vector table version
+	Item2XConf             Item2XConfig // aggregate item triggers to item property(x) triggers, empty XKey means disabled
 }
 
 // Item2XConfig aggregates item level trigger weights into item property(x) level triggers.

--- a/service/recall/recallenginerecall/service_recall.go
+++ b/service/recall/recallenginerecall/service_recall.go
@@ -144,14 +144,16 @@ func NewRecallEngineServiceRecall(client *recallengine.RecallEngineClient, conf 
 			r.recallMap[param.RecallName] = recall
 		case recconf.RecallEngine_RecallType_Vector:
 			recall := &RecallEngineVectorRecall{
-				recallName:     param.RecallName,
-				returnCount:    param.Count,
-				scorerClause:   param.ScorerClause,
-				diversityParam: param.DiversityParam,
-				timeout:        param.Timeout,
-				triggerKey:     NewTriggerKey(&param, client),
-				client:         client,
-				cloneInstances: make(map[string]*RecallEngineVectorRecall),
+				recallName:             param.RecallName,
+				returnCount:            param.Count,
+				scorerClause:           param.ScorerClause,
+				diversityParam:         param.DiversityParam,
+				versionId:              param.VersionId,
+				userEmbeddingVersionId: param.UserEmbeddingVersionId,
+				timeout:                param.Timeout,
+				triggerKey:             NewTriggerKey(&param, client),
+				client:                 client,
+				cloneInstances:         make(map[string]*RecallEngineVectorRecall),
 			}
 
 			r.recallMap[param.RecallName] = recall

--- a/service/recall/recallenginerecall/trigger_key.go
+++ b/service/recall/recallenginerecall/trigger_key.go
@@ -10,6 +10,7 @@ import (
 
 type TriggerResult struct {
 	TriggerItem       string
+	Version           string
 	DistinctParam     string
 	DistinctParamName string
 }

--- a/service/recall/recallenginerecall/user_realtime_embedding_trigger.go
+++ b/service/recall/recallenginerecall/user_realtime_embedding_trigger.go
@@ -104,6 +104,7 @@ func (t *UserRealtimeEmbeddingTrigger) GetTriggerKey(u *module.User, context *co
 	//var triggerItem string
 	//var triggerItems []string
 	var userEmbedding string
+	var version string
 
 	if err != nil {
 		plog.Error(fmt.Sprintf("requestId=%s\tmodule=UserRealtimeEmbeddingTrigger\terr=%v", context.RecommendId, err))
@@ -112,6 +113,11 @@ func (t *UserRealtimeEmbeddingTrigger) GetTriggerKey(u *module.User, context *co
 		if result, ok := algoRet.([]response.AlgoResponse); ok && len(result) > 0 {
 			if embeddingReponse, ok := result[0].(*eas.TorchrecEmbeddingResponse); ok {
 				embeddings := embeddingReponse.GetEmbedding()
+				passThroughData := embeddingReponse.GetPassThroughData()
+				version = strings.TrimSpace(passThroughData["version"])
+				if version == "" {
+					version = strings.TrimSpace(passThroughData["model_version"])
+				}
 				embeddingList := make([]string, 0, len(embeddings))
 				for _, embedding := range embeddings {
 					embeddingList = append(embeddingList, strconv.FormatFloat(float64(embedding), 'f', -1, 32))
@@ -142,6 +148,7 @@ func (t *UserRealtimeEmbeddingTrigger) GetTriggerKey(u *module.User, context *co
 
 	triggerResult := &TriggerResult{
 		TriggerItem: userEmbedding,
+		Version:     version,
 	}
 	//plog.Info(fmt.Sprintf("requestId=%s\tmodule=UserRealtimeEmbeddingTrigger\tcost=%v", context.RecommendId, utils.CostTime(start)))
 	return triggerResult

--- a/service/recall/recallenginerecall/vector_recall.go
+++ b/service/recall/recallenginerecall/vector_recall.go
@@ -22,12 +22,14 @@ type RecallEngineVectorRecall struct {
 	scorerClause string
 	//itemIdName      string
 	//recallTableName string
-	diversityParam string
-	timeout        int
-	triggerKey     TriggerKey
-	client         *recallengine.RecallEngineClient
-	mu             sync.RWMutex
-	cloneInstances map[string]*RecallEngineVectorRecall
+	diversityParam         string
+	versionId              string
+	userEmbeddingVersionId string
+	timeout                int
+	triggerKey             TriggerKey
+	client                 *recallengine.RecallEngineClient
+	mu                     sync.RWMutex
+	cloneInstances         map[string]*RecallEngineVectorRecall
 }
 
 func NewRecallEngineVectorRecall(client *recallengine.RecallEngineClient, conf recconf.RecallEngineConfig) *RecallEngineVectorRecall {
@@ -41,11 +43,13 @@ func NewRecallEngineVectorRecall(client *recallengine.RecallEngineClient, conf r
 		scorerClause: conf.RecallEngineParams[0].ScorerClause,
 		recallName:   conf.RecallEngineParams[0].RecallName,
 		//recallTableName: conf.RecallEngineParams[0].RecallTableName,
-		diversityParam: conf.RecallEngineParams[0].DiversityParam,
-		timeout:        conf.RecallEngineParams[0].Timeout,
-		triggerKey:     NewTriggerKey(&conf.RecallEngineParams[0], nil),
-		client:         client,
-		cloneInstances: make(map[string]*RecallEngineVectorRecall),
+		diversityParam:         conf.RecallEngineParams[0].DiversityParam,
+		versionId:              conf.RecallEngineParams[0].VersionId,
+		userEmbeddingVersionId: conf.RecallEngineParams[0].UserEmbeddingVersionId,
+		timeout:                conf.RecallEngineParams[0].Timeout,
+		triggerKey:             NewTriggerKey(&conf.RecallEngineParams[0], nil),
+		client:                 client,
+		cloneInstances:         make(map[string]*RecallEngineVectorRecall),
 	}
 
 	return &r
@@ -66,11 +70,15 @@ func (r *RecallEngineVectorRecall) BuildQueryParams(user *module.User, context *
 	}
 	ret.Trigger = triggerResult.TriggerItem
 	ret.Count = r.returnCount
+	ret.VersionId = r.versionId
+	ret.UserEmbeddingVersionId = r.userEmbeddingVersionId
+	if triggerResult.Version != "" {
+		ret.VersionId = triggerResult.Version
+	}
 	if r.timeout > 0 {
 		ret.Options = &re.RecallOptions{Timeout: r.timeout}
 	}
 	return
-
 }
 func (r *RecallEngineVectorRecall) CloneWithConfig(params map[string]interface{}) RecallEngineBaseRecall {
 	j, err := json.Marshal(params)
@@ -103,14 +111,16 @@ func (r *RecallEngineVectorRecall) CloneWithConfig(params map[string]interface{}
 	}
 
 	recall = &RecallEngineVectorRecall{
-		serviceName:    r.serviceName,
-		client:         r.client,
-		returnCount:    recallParams.Count,
-		recallName:     r.recallName,
-		diversityParam: recallParams.DiversityParam,
-		timeout:        recallParams.Timeout,
-		triggerKey:     NewTriggerKey(&recallParams, r.client),
-		cloneInstances: make(map[string]*RecallEngineVectorRecall),
+		serviceName:            r.serviceName,
+		client:                 r.client,
+		returnCount:            recallParams.Count,
+		recallName:             r.recallName,
+		diversityParam:         recallParams.DiversityParam,
+		versionId:              recallParams.VersionId,
+		userEmbeddingVersionId: recallParams.UserEmbeddingVersionId,
+		timeout:                recallParams.Timeout,
+		triggerKey:             NewTriggerKey(&recallParams, r.client),
+		cloneInstances:         make(map[string]*RecallEngineVectorRecall),
 	}
 
 	r.cloneInstances[md5] = recall

--- a/service/recall/recallenginerecall/vector_recall.go
+++ b/service/recall/recallenginerecall/vector_recall.go
@@ -87,7 +87,10 @@ func (r *RecallEngineVectorRecall) CloneWithConfig(params map[string]interface{}
 		return r
 	}
 
-	recallParams := recconf.RecallEngineParam{}
+	recallParams := recconf.RecallEngineParam{
+		VersionId:              r.versionId,
+		UserEmbeddingVersionId: r.userEmbeddingVersionId,
+	}
 	if err := json.Unmarshal(j, &recallParams); err != nil {
 		log.Error(fmt.Sprintf("event=CloneWithConfig\terror=%v", err))
 		return r


### PR DESCRIPTION
## Summary

- pass item and user embedding table versions to Recall Engine vector requests
- prefer the item vector version returned by PAI-EAS pass-through data (`version`, with `model_version` fallback)
- retain configured versions as fallback and preserve them in cloned recalls
- upgrade the Recall Engine config SDK to the commit from aliyun/aliyun-pairec-config-go-sdk#31

## Dependency

- Depends on aliyun/aliyun-pairec-config-go-sdk#31

## Testing

- `go test ./recconf ./service/recall/recallenginerecall`