### PR TITLE
feat: support dedicated DebugOutputFields for debug mode output

### DIFF
--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -772,8 +772,12 @@ type CategoryConfig struct {
 	AutoInvokeCallBack     bool
 	AutoInvokeCallBackRate int
 	OutputFields           []string
-	SubRank                map[string]any
-	LogResponseBody        bool
+	// DebugOutputFields is the dedicated output fields used only when the
+	// request carries debug=true. When it is not empty in debug mode, it
+	// completely replaces OutputFields; normal requests are not affected.
+	DebugOutputFields []string
+	SubRank           map[string]any
+	LogResponseBody   bool
 }
 
 type AIChatConfig struct {


### PR DESCRIPTION
## What does this PR do?

Add a new engine config field `DebugOutputFields` to `CategoryConfig`
(`SceneConfs -> scene -> category`), providing dedicated output fields
for debug-mode requests (`debug=true` in the request body), so that
debug requests can expose more fields without affecting normal calls.

## Semantics

- When the request carries `debug=true` and `DebugOutputFields` is not
  empty, it completely replaces `OutputFields`.
- In debug mode without `DebugOutputFields` configured, it falls back
  to `OutputFields`.
- Normal (non-debug) requests are not affected.

## Config example

```json
{
  "SceneConfs": {
    "default_scene": {
      "default": {
        "OutputFields": ["item:title"],
        "DebugOutputFields": ["item:title", "item:tags", "score:*"]
      }
    }
  }
}