### PR TITLE
feat: rank AI shopping results before reply

### DIFF
--- a/algorithm/eas/model.go
+++ b/algorithm/eas/model.go
@@ -128,8 +128,9 @@ func (m *EasModel) Init(conf *recconf.AlgoConfig) error {
 		client.SetToken(conf.EasConf.Auth)
 		client.SetTimeout(conf.EasConf.Timeout)
 		dialTimeout := 100 * time.Millisecond
-		if conf.EasConf.EndpointType != eas.EndpointTypeDirect && conf.EasConf.Timeout > 100 {
-			dialTimeout = time.Duration(conf.EasConf.Timeout) * time.Millisecond
+		configuredTimeout := time.Duration(conf.EasConf.Timeout) * time.Millisecond
+		if conf.EasConf.EndpointType != eas.EndpointTypeDirect && configuredTimeout > dialTimeout {
+			dialTimeout = configuredTimeout
 		}
 		client.SetHttpTransport(&http.Transport{
 			MaxConnsPerHost:       2000,

--- a/algorithm/eas/model.go
+++ b/algorithm/eas/model.go
@@ -127,6 +127,10 @@ func (m *EasModel) Init(conf *recconf.AlgoConfig) error {
 		}
 		client.SetToken(conf.EasConf.Auth)
 		client.SetTimeout(conf.EasConf.Timeout)
+		dialTimeout := 100 * time.Millisecond
+		if conf.EasConf.EndpointType != eas.EndpointTypeDirect && conf.EasConf.Timeout > 100 {
+			dialTimeout = time.Duration(conf.EasConf.Timeout) * time.Millisecond
+		}
 		client.SetHttpTransport(&http.Transport{
 			MaxConnsPerHost:       2000,
 			MaxIdleConnsPerHost:   2000,
@@ -134,7 +138,7 @@ func (m *EasModel) Init(conf *recconf.AlgoConfig) error {
 			TLSHandshakeTimeout:   100 * time.Millisecond,
 			ExpectContinueTimeout: 200 * time.Millisecond,
 			DialContext: (&net.Dialer{
-				Timeout:   100 * time.Millisecond, // 100ms
+				Timeout:   dialTimeout,
 				KeepAlive: 10 * time.Minute,
 			}).DialContext,
 		})

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/alibabacloud-go/tea v1.5.1
 	github.com/alibabacloud-go/tea-utils v1.4.5
 	github.com/aliyun/aliyun-be-go-sdk v1.0.1-0.20230607022243-19a50c32ec4c
-	github.com/aliyun/aliyun-datahub-sdk-go v1.1.4
+	github.com/aliyun/aliyun-datahub-sdk-go v1.2.0
 	github.com/aliyun/aliyun-igraph-go-sdk v0.0.0-20221208132745-defc68e1b227
 	github.com/aliyun/aliyun-log-go-sdk v0.1.27
 	github.com/aliyun/aliyun-tablestore-go-sdk v1.7.7

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/aliyun/alibabacloud-lindorm-go-sql-driver/v5 v5.0.1 h1:9IbLal5XJrZ5f4
 github.com/aliyun/alibabacloud-lindorm-go-sql-driver/v5 v5.0.1/go.mod h1:eCk9u8X533+Sd9CTfI2Mn59ok6Ck/9t7jXHz+FO601g=
 github.com/aliyun/aliyun-be-go-sdk v1.0.1-0.20230607022243-19a50c32ec4c h1:5YWOrdiCtaOjh/IJvn+Aht6vtUeJtBxWLqe5sewcbjg=
 github.com/aliyun/aliyun-be-go-sdk v1.0.1-0.20230607022243-19a50c32ec4c/go.mod h1:wj5PXdQyCNS9n4Og3CH03MAxhuNJM9OrD8o5hoCMXEM=
-github.com/aliyun/aliyun-datahub-sdk-go v1.1.4 h1:0jjT+nddwHxWT979vZwfCh7xqktOiRJjkKc76Csp/Nk=
-github.com/aliyun/aliyun-datahub-sdk-go v1.1.4/go.mod h1:IGmdWriyt86EHENmRuqwAQIEje0wU7EeVXiDREktcj8=
+github.com/aliyun/aliyun-datahub-sdk-go v1.2.0 h1:KqTQUWu/YW4Vto/KWTkczwa04NN2r7PEEzvvZupLZyo=
+github.com/aliyun/aliyun-datahub-sdk-go v1.2.0/go.mod h1:IGmdWriyt86EHENmRuqwAQIEje0wU7EeVXiDREktcj8=
 github.com/aliyun/aliyun-igraph-go-sdk v0.0.0-20221208132745-defc68e1b227 h1:NBHpE+HPsmtvHTFCzt5hUsaj+xBt+t5cgUrbqZ4KH+k=
 github.com/aliyun/aliyun-igraph-go-sdk v0.0.0-20221208132745-defc68e1b227/go.mod h1:k+nixj5x99h1pIn/7RyAxeMtig9PvnCFdDNzHduLqWU=
 github.com/aliyun/aliyun-log-go-sdk v0.1.27 h1:fXtaOAcdR3DsqN9GZkfJue8B2Dba0TV+8Ahwq4o+y5g=

--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -833,6 +833,12 @@ type AIChatConfig struct {
 	SessionFeatureView          string
 	SessionMaxTurns             int
 	SessionMaxTokens            int
+	FineRankConfig              *AIShoppingFineRankConfig
+}
+
+type AIShoppingFineRankConfig struct {
+	CandidateCount int
+	RankConf       RankConfig
 }
 
 type SuggestionConfig struct {

--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -772,8 +772,12 @@ type CategoryConfig struct {
 	AutoInvokeCallBack     bool
 	AutoInvokeCallBackRate int
 	OutputFields           []string
-	SubRank                map[string]any
-	LogResponseBody        bool
+	// DebugOutputFields is the dedicated output fields used only when the
+	// request carries debug=true. When it is not empty in debug mode, it
+	// completely replaces OutputFields; normal requests are not affected.
+	DebugOutputFields []string
+	SubRank           map[string]any
+	LogResponseBody   bool
 }
 
 type AIChatConfig struct {

--- a/service/aishopping/agent_loop.go
+++ b/service/aishopping/agent_loop.go
@@ -20,6 +20,7 @@ import (
 const (
 	toolArgumentsLogLimit        = 2048
 	fieldAwareSearchRetryMessage = "The previous search_goods call was invalid. Return exactly one tool call and no prose. Follow all required fields and array constraints, and omit optional prices when absent."
+	fineRankReplyInstruction     = "The search_goods tool result is already ordered from highest to lowest recommendation priority. Treat this order as authoritative. Recommend and cite products in this order; when space is limited, use a prefix of the list. Do not re-rank products or mention ranking scores, models, or this instruction."
 )
 
 var optionalPriceNullLikePattern = regexp.MustCompile(
@@ -129,6 +130,9 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 			})
 		}
 		plannerMessages := messagesWithPrompt(messages, prompt)
+		if readyToReply && cfg.raw.FineRankConfig != nil {
+			plannerMessages = messagesWithFineRankInstruction(plannerMessages)
+		}
 		if !readyToReply {
 			plannerMessages = messagesWithKnowledge(plannerMessages, cfg.raw.KnowledgePlannerInstruction, knowledge)
 		}
@@ -232,7 +236,10 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 		for i, toolCall := range result.ToolCalls {
 			log.Info(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=tool_call_args\tround=%d\ttoolIndex=%d\ttool=%s\targs=%s",
 				meta.requestId, meta.uid, meta.sessionId, round, i, toolCall.Function.Name, compactJSONString(toolCall.Function.Arguments, toolArgumentsLogLimit)))
-			toolResult := dispatchTool(ctx, recall, toolCall, state, cfg.raw.DisplayItemCountMax, fieldAwareSearch, knowledge, onFinalSearch != nil, meta, round)
+			toolResult := dispatchTool(ctx, recall, toolCall, state, cfg, fieldAwareSearch, knowledge, onFinalSearch != nil, meta, round)
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
 			blob.Messages = append(blob.Messages, aichat.Message{
 				Role:       "tool",
 				ToolCallId: toolCall.ID,
@@ -274,7 +281,7 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 	return loopResult(fallbackText(cfg.raw, cfg.language, "empty_after_tools"), false, true), nil
 }
 
-func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCall, state *turnState, limit int, fieldAware bool, knowledge *knowledgeEvidence, captureFinalSearch bool, meta timingMeta, round int) toolDispatchResult {
+func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCall, state *turnState, cfg *chatConfig, fieldAware bool, knowledge *knowledgeEvidence, captureFinalSearch bool, meta timingMeta, round int) toolDispatchResult {
 	if toolCall.Function.Name != "search_goods" {
 		return toolDispatchResult{content: `{"error":"unsupported tool"}`, hasError: true}
 	}
@@ -284,7 +291,11 @@ func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCa
 			meta.requestId, meta.uid, meta.sessionId, round, err, compactJSONString(toolCall.Function.Arguments, toolArgumentsLogLimit)))
 		return toolDispatchResult{content: fmt.Sprintf(`{"error":%q}`, err.Error()), isSearch: true, hasError: true}
 	}
-	req.Limit = limit
+	displayLimit := cfg.raw.DisplayItemCountMax
+	req.Limit = displayLimit
+	if cfg.raw.FineRankConfig != nil {
+		req.Limit = cfg.raw.FineRankConfig.CandidateCount
+	}
 	req.MultiFieldFallback = fieldAware
 	dispatchResult := toolDispatchResult{
 		isSearch:     true,
@@ -307,7 +318,19 @@ func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCa
 	log.Info(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=opensearch_recall\tround=%d\tkeywords=%s\toperator=%s\tlimit=%d\ttotal=%d\thits=%d\tfallbackUsed=%t\titemIds=%s\trouteErrors=%s\tcost=%d",
 		meta.requestId, meta.uid, meta.sessionId, round, compactJSON(req.Keywords), dispatchResult.operator, req.Limit, result.Total, len(result.Hits), result.FallbackUsed, compactJSON(searchResultItemIds(result)), compactJSON(result.RouteErrors), recallCost))
 	dispatchResult.total = result.Total
-	modelResult := annotateSearchResult(result, state)
+	if cfg.raw.FineRankConfig != nil && len(result.Hits) > 1 {
+		rankedHits, rankErr := fineRankGoods(ctx, req, result.Hits, meta.uid, cfg.raw.FineRankConfig)
+		if rankErr != nil {
+			log.Warning(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=fine_rank\tround=%d\terr=%s",
+				meta.requestId, meta.uid, meta.sessionId, round, compactLogError(rankErr)))
+		} else {
+			result.Hits = rankedHits
+		}
+	}
+	if len(result.Hits) > displayLimit {
+		result.Hits = result.Hits[:displayLimit]
+	}
+	modelResult := annotateSearchResult(result, state, cfg.raw.FineRankConfig == nil)
 	payload, err := json.Marshal(modelResult)
 	if err != nil {
 		dispatchResult.content = fmt.Sprintf(`{"error":%q}`, err.Error())
@@ -507,7 +530,7 @@ func compactLogError(err error) string {
 	return truncateLogValue(strings.Join(strings.Fields(err.Error()), " "), toolArgumentsLogLimit)
 }
 
-func annotateSearchResult(result *recallsvc.SearchGoodsResult, state *turnState) map[string]interface{} {
+func annotateSearchResult(result *recallsvc.SearchGoodsResult, state *turnState, includeScore bool) map[string]interface{} {
 	modelHits := make([]map[string]interface{}, 0, len(result.Hits))
 	for _, hit := range result.Hits {
 		index := state.itemToIndex[hit.ItemId]
@@ -526,7 +549,7 @@ func annotateSearchResult(result *recallsvc.SearchGoodsResult, state *turnState)
 		if hit.Content != "" {
 			modelHit["content"] = hit.Content
 		}
-		if hit.Score != nil {
+		if includeScore && hit.Score != nil {
 			modelHit["score"] = hit.Score
 		}
 		raw := make(map[string]interface{}, len(hit.Properties))
@@ -542,4 +565,14 @@ func annotateSearchResult(result *recallsvc.SearchGoodsResult, state *turnState)
 		modelHits = append(modelHits, modelHit)
 	}
 	return map[string]interface{}{"total": result.Total, "hits": modelHits}
+}
+
+func messagesWithFineRankInstruction(messages []aichat.Message) []aichat.Message {
+	if len(messages) == 0 {
+		return []aichat.Message{{Role: "system", Content: fineRankReplyInstruction}}
+	}
+	result := make([]aichat.Message, 0, len(messages)+1)
+	result = append(result, messages[0])
+	result = append(result, aichat.Message{Role: "system", Content: fineRankReplyInstruction})
+	return append(result, messages[1:]...)
 }

--- a/service/aishopping/agent_loop.go
+++ b/service/aishopping/agent_loop.go
@@ -20,7 +20,6 @@ import (
 const (
 	toolArgumentsLogLimit        = 2048
 	fieldAwareSearchRetryMessage = "The previous search_goods call was invalid. Return exactly one tool call and no prose. Follow all required fields and array constraints, and omit optional prices when absent."
-	fineRankReplyInstruction     = "The search_goods tool result is already ordered from highest to lowest recommendation priority. Treat this order as authoritative. Recommend and cite products in this order; when space is limited, use a prefix of the list. Do not re-rank products or mention ranking scores, models, or this instruction."
 )
 
 var optionalPriceNullLikePattern = regexp.MustCompile(
@@ -28,9 +27,10 @@ var optionalPriceNullLikePattern = regexp.MustCompile(
 )
 
 type turnState struct {
-	indexMap    map[int]string
-	itemToIndex map[string]int
-	nextIndex   int
+	indexMap     map[int]string
+	itemToIndex  map[string]int
+	nextIndex    int
+	replyItemIDs []string
 }
 
 type chatRecall interface {
@@ -40,6 +40,7 @@ type chatRecall interface {
 type agentLoopResult struct {
 	Reply               string
 	IndexMap            map[int]string
+	ReplyItemIDs        []string
 	ReplyAlreadyEmitted bool
 	MainReplyFallback   bool
 	FinalSearchStatus   finalSearchStatus
@@ -84,7 +85,7 @@ func (r toolDispatchResult) shouldRetryWithFallback(tried bool) bool {
 	return r.isSearch && !r.hasError && r.operator == "AND" && r.total == 0 && r.keywordCount > 1 && !tried
 }
 
-func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, blob *SessionBlob, cfg *chatConfig, knowledge *knowledgeEvidence, writer *StreamWriter, meta timingMeta, onFinalSearch func(context.Context, *finalSearchSnapshot)) (*agentLoopResult, error) {
+func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, blob *SessionBlob, cfg *chatConfig, rankRuntime *fineRankRuntime, knowledge *knowledgeEvidence, writer *StreamWriter, meta timingMeta, onFinalSearch func(context.Context, *finalSearchSnapshot)) (*agentLoopResult, error) {
 	state := &turnState{
 		indexMap:    make(map[int]string),
 		itemToIndex: make(map[string]int),
@@ -95,6 +96,7 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 		return &agentLoopResult{
 			Reply:               reply,
 			IndexMap:            state.indexMap,
+			ReplyItemIDs:        append([]string(nil), state.replyItemIDs...),
 			ReplyAlreadyEmitted: emitted,
 			MainReplyFallback:   fallback,
 			FinalSearchStatus:   finalStatus,
@@ -130,9 +132,6 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 			})
 		}
 		plannerMessages := messagesWithPrompt(messages, prompt)
-		if readyToReply && cfg.raw.FineRankConfig != nil {
-			plannerMessages = messagesWithFineRankInstruction(plannerMessages)
-		}
 		if !readyToReply {
 			plannerMessages = messagesWithKnowledge(plannerMessages, cfg.raw.KnowledgePlannerInstruction, knowledge)
 		}
@@ -156,7 +155,13 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 		} else if !fieldAwareSearch && round == cfg.raw.ToolMaxRounds {
 			llmReq.ToolChoice = "none"
 		}
-		streamer := newReplyStreamer(writer, state.indexMap, cfg.raw.DisplayItemCountMax)
+		streamer := newReplyStreamer(
+			writer,
+			state.indexMap,
+			state.replyItemIDs,
+			cfg.raw.DisplayItemCountMax,
+			readyToReply && rankRuntime != nil,
+		)
 		var streamErr error
 		llmPhase := "planner_llm"
 		if readyToReply {
@@ -236,9 +241,11 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 		for i, toolCall := range result.ToolCalls {
 			log.Info(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=tool_call_args\tround=%d\ttoolIndex=%d\ttool=%s\targs=%s",
 				meta.requestId, meta.uid, meta.sessionId, round, i, toolCall.Function.Name, compactJSONString(toolCall.Function.Arguments, toolArgumentsLogLimit)))
-			toolResult := dispatchTool(ctx, recall, toolCall, state, cfg, fieldAwareSearch, knowledge, onFinalSearch != nil, meta, round)
-			if err := ctx.Err(); err != nil {
-				return nil, err
+			toolResult := dispatchTool(ctx, recall, toolCall, state, cfg, rankRuntime, fieldAwareSearch, knowledge, onFinalSearch != nil, meta, round)
+			if rankRuntime != nil {
+				if err := ctx.Err(); err != nil {
+					return nil, err
+				}
 			}
 			blob.Messages = append(blob.Messages, aichat.Message{
 				Role:       "tool",
@@ -281,7 +288,7 @@ func runAgentLoop(ctx context.Context, model *aichat.Model, recall chatRecall, b
 	return loopResult(fallbackText(cfg.raw, cfg.language, "empty_after_tools"), false, true), nil
 }
 
-func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCall, state *turnState, cfg *chatConfig, fieldAware bool, knowledge *knowledgeEvidence, captureFinalSearch bool, meta timingMeta, round int) toolDispatchResult {
+func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCall, state *turnState, cfg *chatConfig, rankRuntime *fineRankRuntime, fieldAware bool, knowledge *knowledgeEvidence, captureFinalSearch bool, meta timingMeta, round int) toolDispatchResult {
 	if toolCall.Function.Name != "search_goods" {
 		return toolDispatchResult{content: `{"error":"unsupported tool"}`, hasError: true}
 	}
@@ -292,9 +299,10 @@ func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCa
 		return toolDispatchResult{content: fmt.Sprintf(`{"error":%q}`, err.Error()), isSearch: true, hasError: true}
 	}
 	displayLimit := cfg.raw.DisplayItemCountMax
+	fineRank := cfg.raw.FineRankConfig
 	req.Limit = displayLimit
-	if cfg.raw.FineRankConfig != nil {
-		req.Limit = cfg.raw.FineRankConfig.CandidateCount
+	if fineRank != nil {
+		req.Limit = fineRank.CandidateCount
 	}
 	req.MultiFieldFallback = fieldAware
 	dispatchResult := toolDispatchResult{
@@ -318,19 +326,21 @@ func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCa
 	log.Info(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=opensearch_recall\tround=%d\tkeywords=%s\toperator=%s\tlimit=%d\ttotal=%d\thits=%d\tfallbackUsed=%t\titemIds=%s\trouteErrors=%s\tcost=%d",
 		meta.requestId, meta.uid, meta.sessionId, round, compactJSON(req.Keywords), dispatchResult.operator, req.Limit, result.Total, len(result.Hits), result.FallbackUsed, compactJSON(searchResultItemIds(result)), compactJSON(result.RouteErrors), recallCost))
 	dispatchResult.total = result.Total
-	if cfg.raw.FineRankConfig != nil && len(result.Hits) > 1 {
-		rankedHits, rankErr := fineRankGoods(ctx, req, result.Hits, meta.uid, cfg.raw.FineRankConfig)
-		if rankErr != nil {
-			log.Warning(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=fine_rank\tround=%d\terr=%s",
-				meta.requestId, meta.uid, meta.sessionId, round, compactLogError(rankErr)))
-		} else {
-			result.Hits = rankedHits
+	if fineRank != nil {
+		if len(result.Hits) > 1 {
+			rankedHits, rankErr := fineRankGoods(ctx, result.Hits, rankRuntime, fineRank)
+			if rankErr != nil {
+				log.Warning(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=fine_rank\tround=%d\terr=%s",
+					meta.requestId, meta.uid, meta.sessionId, round, compactLogError(rankErr)))
+			} else {
+				result.Hits = rankedHits
+			}
+		}
+		if len(result.Hits) > displayLimit {
+			result.Hits = result.Hits[:displayLimit]
 		}
 	}
-	if len(result.Hits) > displayLimit {
-		result.Hits = result.Hits[:displayLimit]
-	}
-	modelResult := annotateSearchResult(result, state, cfg.raw.FineRankConfig == nil)
+	modelResult := annotateSearchResult(result, state, fineRank == nil)
 	payload, err := json.Marshal(modelResult)
 	if err != nil {
 		dispatchResult.content = fmt.Sprintf(`{"error":%q}`, err.Error())
@@ -338,6 +348,9 @@ func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCa
 		return dispatchResult
 	}
 	dispatchResult.content = string(payload)
+	if fineRank != nil {
+		state.replyItemIDs = searchResultItemIds(result)
+	}
 	if !captureFinalSearch {
 		return dispatchResult
 	}
@@ -565,14 +578,4 @@ func annotateSearchResult(result *recallsvc.SearchGoodsResult, state *turnState,
 		modelHits = append(modelHits, modelHit)
 	}
 	return map[string]interface{}{"total": result.Total, "hits": modelHits}
-}
-
-func messagesWithFineRankInstruction(messages []aichat.Message) []aichat.Message {
-	if len(messages) == 0 {
-		return []aichat.Message{{Role: "system", Content: fineRankReplyInstruction}}
-	}
-	result := make([]aichat.Message, 0, len(messages)+1)
-	result = append(result, messages[0])
-	result = append(result, aichat.Message{Role: "system", Content: fineRankReplyInstruction})
-	return append(result, messages[1:]...)
 }

--- a/service/aishopping/citation.go
+++ b/service/aishopping/citation.go
@@ -19,15 +19,55 @@ type ReplyEvent struct {
 	ItemId  string
 }
 
-func resolveReplyEvents(reply string, indexMap map[int]string, maxItems int) (string, []ReplyEvent) {
+type replyMarkerResolver struct {
+	indexMap      map[int]string
+	sequentialIDs []string
+	nextPos       int
+	strict        bool
+}
+
+func newReplyMarkerResolver(indexMap map[int]string, replyItemIDs []string, maxItems int, strict bool) *replyMarkerResolver {
+	sequentialIDs := orderedItemIDs(indexMap, maxItems)
+	if strict {
+		count := len(replyItemIDs)
+		if maxItems <= 0 {
+			count = 0
+		} else if count > maxItems {
+			count = maxItems
+		}
+		sequentialIDs = append([]string(nil), replyItemIDs[:count]...)
+	}
+	return &replyMarkerResolver{
+		indexMap:      indexMap,
+		sequentialIDs: sequentialIDs,
+		strict:        strict,
+	}
+}
+
+func (r *replyMarkerResolver) nextRef() string {
+	if r.nextPos >= len(r.sequentialIDs) {
+		return ""
+	}
+	itemID := r.sequentialIDs[r.nextPos]
+	r.nextPos++
+	return itemID
+}
+
+func (r *replyMarkerResolver) resolveIndex(index int) string {
+	if r.strict {
+		return r.nextRef()
+	}
+	return r.indexMap[index]
+}
+
+func resolveReplyEvents(reply string, indexMap map[int]string, replyItemIDs []string, maxItems int, strictRankOrder bool) (string, []ReplyEvent) {
 	events := make([]ReplyEvent, 0)
 	canonical := ""
 	pos := 0
 	used := 0
 	seenItemIDs := make(map[string]struct{})
 	var textState markerTextState
-	refIDs := orderedItemIDs(indexMap, maxItems)
-	refPos := 0
+	resolver := newReplyMarkerResolver(indexMap, replyItemIDs, maxItems, strictRankOrder)
 	matches := replyRefRegexp.FindAllStringSubmatchIndex(reply, -1)
 	for _, match := range matches {
 		text := textState.consume(reply[pos:match[0]])
@@ -43,10 +83,9 @@ func resolveReplyEvents(reply string, indexMap map[int]string, maxItems int) (st
 			if err != nil {
 				continue
 			}
-			itemID = indexMap[n]
-		} else if refPos < len(refIDs) {
-			itemID = refIDs[refPos]
-			refPos++
+			itemID = resolver.resolveIndex(n)
+		} else {
+			itemID = resolver.nextRef()
 		}
 		if itemID == "" || used >= maxItems {
 			continue

--- a/service/aishopping/config.go
+++ b/service/aishopping/config.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/alibaba/pairec/v2/recconf"
+	"github.com/alibaba/pairec/v2/utils/ast"
 )
 
 func resolveConfig(config *recconf.RecommendConfig, sceneId, language string) (*chatConfig, error) {
@@ -20,6 +21,9 @@ func resolveConfig(config *recconf.RecommendConfig, sceneId, language string) (*
 		return nil, fmt.Errorf("AIChatConfig not found for scene:%s", sceneId)
 	}
 	cfg := normalizeConfig(cloneAIChatConfig(category.AIChatConfig))
+	if err := validateFineRankConfig(config.AlgoConfs, cfg); err != nil {
+		return nil, err
+	}
 	if language == "" {
 		language = cfg.DefaultLanguage
 	}
@@ -105,7 +109,52 @@ func cloneAIChatConfig(cfg *recconf.AIChatConfig) *recconf.AIChatConfig {
 	cloned.PlannerPromptTemplates = cloneStringMap(cfg.PlannerPromptTemplates)
 	cloned.ReplyPromptTemplates = cloneStringMap(cfg.ReplyPromptTemplates)
 	cloned.FallbackTemplates = cloneNestedStringMap(cfg.FallbackTemplates)
+	if cfg.FineRankConfig != nil {
+		fineRank := *cfg.FineRankConfig
+		fineRank.RankConf.RankAlgoList = append([]string(nil), cfg.FineRankConfig.RankConf.RankAlgoList...)
+		fineRank.RankConf.ContextFeatures = append([]string(nil), cfg.FineRankConfig.RankConf.ContextFeatures...)
+		fineRank.RankConf.ItemFeatures = append([]string(nil), cfg.FineRankConfig.RankConf.ItemFeatures...)
+		cloned.FineRankConfig = &fineRank
+	}
 	return &cloned
+}
+
+func validateFineRankConfig(algoConfs []recconf.AlgoConfig, cfg *recconf.AIChatConfig) error {
+	fineRank := cfg.FineRankConfig
+	if fineRank == nil {
+		return nil
+	}
+	if fineRank.CandidateCount < cfg.DisplayItemCountMax {
+		return fmt.Errorf("FineRankConfig.CandidateCount must be >= DisplayItemCountMax")
+	}
+	rankConf := fineRank.RankConf
+	if len(rankConf.RankAlgoList) != 1 {
+		return fmt.Errorf("FineRankConfig.RankConf.RankAlgoList must contain exactly one algorithm")
+	}
+	algoName := strings.TrimSpace(rankConf.RankAlgoList[0])
+	if algoName == "" || !containsAlgo(algoConfs, algoName) {
+		return fmt.Errorf("FineRankConfig algorithm not found:%s", algoName)
+	}
+	fineRank.RankConf.RankAlgoList[0] = algoName
+	if strings.TrimSpace(rankConf.RankScore) == "" {
+		return fmt.Errorf("FineRankConfig.RankConf.RankScore is required")
+	}
+	if rankConf.BatchCount != 0 || len(rankConf.ScoreRewrite) != 0 {
+		return fmt.Errorf("FineRankConfig does not support BatchCount or ScoreRewrite")
+	}
+	if _, err := ast.GetExpASTWithType(rankConf.RankScore, rankConf.ASTType); err != nil {
+		return fmt.Errorf("invalid FineRankConfig.RankConf.RankScore: %w", err)
+	}
+	return nil
+}
+
+func containsAlgo(algoConfs []recconf.AlgoConfig, name string) bool {
+	for _, algoConf := range algoConfs {
+		if algoConf.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func cloneStringMap(values map[string]string) map[string]string {

--- a/service/aishopping/fine_rank.go
+++ b/service/aishopping/fine_rank.go
@@ -1,0 +1,158 @@
+package aishopping
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/alibaba/pairec/v2/algorithm"
+	"github.com/alibaba/pairec/v2/algorithm/eas"
+	"github.com/alibaba/pairec/v2/algorithm/response"
+	"github.com/alibaba/pairec/v2/module"
+	"github.com/alibaba/pairec/v2/recconf"
+	"github.com/alibaba/pairec/v2/service/rank"
+	recallsvc "github.com/alibaba/pairec/v2/service/recall"
+	"github.com/alibaba/pairec/v2/utils"
+	"github.com/alibaba/pairec/v2/utils/ast"
+)
+
+func fineRankGoods(ctx context.Context, req recallsvc.SearchGoodsRequest, hits []recallsvc.GoodsHit, uid string, conf *recconf.AIShoppingFineRankConfig) ([]recallsvc.GoodsHit, error) {
+	if conf == nil || len(hits) <= 1 {
+		return append([]recallsvc.GoodsHit(nil), hits...), nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	rankConf := conf.RankConf
+	algoName := rankConf.RankAlgoList[0]
+	generator := rank.CreateAlgoDataGenerator(rankConf.Processor, rankConf.ContextFeatures)
+	if rankConf.Processor == eas.Eas_Processor_EASYREC {
+		generator.SetItemFeatures(rankConf.ItemFeatures)
+	}
+
+	user := module.NewUser(uid)
+	user.SetProperties(fineRankUserFeatures(req, uid))
+	userFeatures := user.MakeUserFeatures()
+	if rankConf.Processor == eas.Eas_Processor_EASYREC {
+		userFeatures = user.MakeUserFeatures2()
+	}
+
+	items := make([]*module.Item, 0, len(hits))
+	for i, hit := range hits {
+		item := fineRankItem(hit, i)
+		items = append(items, item)
+		generator.AddFeatures(item, item.GetFeatures(), userFeatures)
+	}
+	if !generator.HasFeatures() {
+		return nil, fmt.Errorf("fine rank request has no features")
+	}
+
+	algoData := generator.GeneratorAlgoData()
+	result, err := algorithm.Run(algoName, algoData.GetFeatures())
+	if err != nil {
+		return nil, fmt.Errorf("run fine rank algorithm %s: %w", algoName, err)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	responses, ok := result.([]response.AlgoResponse)
+	if !ok {
+		return nil, fmt.Errorf("fine rank algorithm %s returned %T", algoName, result)
+	}
+	if len(responses) != len(items) {
+		return nil, fmt.Errorf("fine rank result count mismatch: got %d, want %d", len(responses), len(items))
+	}
+
+	expr, err := ast.GetExpASTWithType(rankConf.RankScore, rankConf.ASTType)
+	if err != nil {
+		return nil, fmt.Errorf("parse fine rank score: %w", err)
+	}
+	type scoredHit struct {
+		hit   recallsvc.GoodsHit
+		score float64
+	}
+	scored := make([]scoredHit, len(hits))
+	for i, algoResponse := range responses {
+		if err := addFineRankResponse(items[i], algoName, algoResponse); err != nil {
+			return nil, err
+		}
+		score := ast.ExprASTResultWithType(expr, items[i], rankConf.ASTType)
+		if math.IsNaN(score) || math.IsInf(score, 0) {
+			return nil, fmt.Errorf("fine rank returned non-finite score for item %s", hits[i].ItemId)
+		}
+		scored[i] = scoredHit{hit: hits[i], score: score}
+	}
+
+	sort.SliceStable(scored, func(i, j int) bool {
+		return scored[i].score > scored[j].score
+	})
+	ranked := make([]recallsvc.GoodsHit, len(scored))
+	for i, item := range scored {
+		ranked[i] = item.hit
+	}
+	return ranked, nil
+}
+
+func fineRankUserFeatures(req recallsvc.SearchGoodsRequest, uid string) map[string]interface{} {
+	features := map[string]interface{}{
+		"uid":                      uid,
+		"aishopping_keywords":      req.Keywords,
+		"aishopping_product_types": req.ProductTypeKeywords,
+		"aishopping_attributes":    req.AttributeKeywords,
+		"aishopping_excludes":      req.ExcludeKeywords,
+		"aishopping_operator":      req.Operator,
+	}
+	if req.MinPrice != nil {
+		features["aishopping_min_price"] = *req.MinPrice
+	}
+	if req.MaxPrice != nil {
+		features["aishopping_max_price"] = *req.MaxPrice
+	}
+	return features
+}
+
+func fineRankItem(hit recallsvc.GoodsHit, position int) *module.Item {
+	properties := make(map[string]interface{}, len(hit.Properties)+5)
+	for key, value := range hit.Properties {
+		properties[key] = value
+	}
+	properties["item_id"] = hit.ItemId
+	properties["title"] = hit.Title
+	properties["content"] = hit.Content
+	properties["aishopping_recall_position"] = position + 1
+	if hit.Score != nil {
+		properties["aishopping_recall_score"] = utils.ToFloat(hit.Score, 0)
+	}
+	item := module.NewItemWithProperty(hit.ItemId, properties)
+	item.Score = utils.ToFloat(hit.Score, 0)
+	return item
+}
+
+func addFineRankResponse(item *module.Item, algoName string, algoResponse response.AlgoResponse) error {
+	if algoResponse == nil {
+		return fmt.Errorf("fine rank algorithm %s returned nil response", algoName)
+	}
+	if algoResponse.GetModuleType() {
+		scores := algoResponse.GetScoreMap()
+		if len(scores) == 0 {
+			return fmt.Errorf("fine rank algorithm %s returned empty score map", algoName)
+		}
+		for name, score := range scores {
+			if math.IsNaN(score) || math.IsInf(score, 0) {
+				return fmt.Errorf("fine rank algorithm %s returned non-finite score", algoName)
+			}
+			item.AddAlgoScore(algoName+"_"+name, score)
+		}
+		return nil
+	}
+
+	score := algoResponse.GetScore()
+	if math.IsNaN(score) || math.IsInf(score, 0) {
+		return fmt.Errorf("fine rank algorithm %s returned non-finite score", algoName)
+	}
+	item.AddAlgoScore(algoName, score)
+	return nil
+}

--- a/service/aishopping/fine_rank.go
+++ b/service/aishopping/fine_rank.go
@@ -9,15 +9,77 @@ import (
 	"github.com/alibaba/pairec/v2/algorithm"
 	"github.com/alibaba/pairec/v2/algorithm/eas"
 	"github.com/alibaba/pairec/v2/algorithm/response"
+	paireccontext "github.com/alibaba/pairec/v2/context"
 	"github.com/alibaba/pairec/v2/module"
 	"github.com/alibaba/pairec/v2/recconf"
+	"github.com/alibaba/pairec/v2/service/feature"
 	"github.com/alibaba/pairec/v2/service/rank"
 	recallsvc "github.com/alibaba/pairec/v2/service/recall"
 	"github.com/alibaba/pairec/v2/utils"
 	"github.com/alibaba/pairec/v2/utils/ast"
 )
 
-func fineRankGoods(ctx context.Context, req recallsvc.SearchGoodsRequest, hits []recallsvc.GoodsHit, uid string, conf *recconf.AIShoppingFineRankConfig) ([]recallsvc.GoodsHit, error) {
+type fineRankRuntime struct {
+	prepared             bool
+	prepareErr           error
+	recommendContext     *paireccontext.RecommendContext
+	user                 *module.User
+	loadUserFeatures     bool
+	loadRankUserFeatures bool
+}
+
+func newFineRankRuntime(req *Request) *fineRankRuntime {
+	recommendContext := paireccontext.NewRecommendContext()
+	recommendContext.Param = req
+	recommendContext.Config = req.Config
+	recommendContext.RecommendId = req.RequestId
+
+	runtime := &fineRankRuntime{
+		recommendContext: recommendContext,
+		user:             module.NewUserWithContext(module.UID(req.Uid), recommendContext),
+	}
+	if req.Config == nil {
+		return runtime
+	}
+	if scene, ok := req.Config.UserFeatureConfs[req.SceneId]; ok {
+		runtime.loadUserFeatures = len(scene.FeatureLoadConfs) > 0
+	}
+	if scene, ok := req.Config.FeatureConfs[req.SceneId]; ok {
+		for _, conf := range scene.FeatureLoadConfs {
+			if conf.FeatureDaoConf.FeatureStore == module.Feature_Store_User {
+				runtime.loadRankUserFeatures = true
+				break
+			}
+		}
+	}
+	return runtime
+}
+
+func (r *fineRankRuntime) prepareUser(ctx context.Context) (*module.User, error) {
+	if r == nil || r.user == nil || r.recommendContext == nil {
+		return nil, fmt.Errorf("fine rank runtime is nil")
+	}
+	if r.prepared {
+		return r.user, r.prepareErr
+	}
+	r.prepared = true
+	if r.loadUserFeatures {
+		feature.DefaultUserFeatureService().LoadUserFeatures(r.user, r.recommendContext)
+		if r.user.FeatureAsyncLoadCount() > 0 {
+			select {
+			case <-r.user.FeatureAsyncLoadCh():
+			case <-ctx.Done():
+				r.prepareErr = ctx.Err()
+			}
+		}
+	}
+	if r.prepareErr == nil && r.loadRankUserFeatures {
+		feature.DefaultFeatureService().LoadFeatures(r.user, nil, r.recommendContext)
+	}
+	return r.user, r.prepareErr
+}
+
+func fineRankGoods(ctx context.Context, hits []recallsvc.GoodsHit, runtime *fineRankRuntime, conf *recconf.AIShoppingFineRankConfig) ([]recallsvc.GoodsHit, error) {
 	if conf == nil || len(hits) <= 1 {
 		return append([]recallsvc.GoodsHit(nil), hits...), nil
 	}
@@ -32,8 +94,10 @@ func fineRankGoods(ctx context.Context, req recallsvc.SearchGoodsRequest, hits [
 		generator.SetItemFeatures(rankConf.ItemFeatures)
 	}
 
-	user := module.NewUser(uid)
-	user.SetProperties(fineRankUserFeatures(req, uid))
+	user, err := runtime.prepareUser(ctx)
+	if err != nil {
+		return nil, err
+	}
 	userFeatures := user.MakeUserFeatures()
 	if rankConf.Processor == eas.Eas_Processor_EASYREC {
 		userFeatures = user.MakeUserFeatures2()
@@ -94,24 +158,6 @@ func fineRankGoods(ctx context.Context, req recallsvc.SearchGoodsRequest, hits [
 		ranked[i] = item.hit
 	}
 	return ranked, nil
-}
-
-func fineRankUserFeatures(req recallsvc.SearchGoodsRequest, uid string) map[string]interface{} {
-	features := map[string]interface{}{
-		"uid":                      uid,
-		"aishopping_keywords":      req.Keywords,
-		"aishopping_product_types": req.ProductTypeKeywords,
-		"aishopping_attributes":    req.AttributeKeywords,
-		"aishopping_excludes":      req.ExcludeKeywords,
-		"aishopping_operator":      req.Operator,
-	}
-	if req.MinPrice != nil {
-		features["aishopping_min_price"] = *req.MinPrice
-	}
-	if req.MaxPrice != nil {
-		features["aishopping_max_price"] = *req.MaxPrice
-	}
-	return features
 }
 
 func fineRankItem(hit recallsvc.GoodsHit, position int) *module.Item {

--- a/service/aishopping/orchestrator.go
+++ b/service/aishopping/orchestrator.go
@@ -117,7 +117,11 @@ func (o *ChatSearchOrchestrator) Run(ctx context.Context, req *Request, writer *
 			onFinalSearch = coordinator.OnFinalSearch
 		}
 	}
-	loopResult, err := runAgentLoop(ctx, model, chatRecall, blob, cfg, knowledge, writer, meta, onFinalSearch)
+	var rankRuntime *fineRankRuntime
+	if cfg.raw.FineRankConfig != nil {
+		rankRuntime = newFineRankRuntime(req)
+	}
+	loopResult, err := runAgentLoop(ctx, model, chatRecall, blob, cfg, rankRuntime, knowledge, writer, meta, onFinalSearch)
 	if err != nil {
 		log.Error(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=upstream\terr=%v",
 			req.RequestId, req.Uid, req.SessionId, err))
@@ -125,7 +129,13 @@ func (o *ChatSearchOrchestrator) Run(ctx context.Context, req *Request, writer *
 		return err
 	}
 	reply := loopResult.Reply
-	canonical, events := resolveReplyEvents(reply, loopResult.IndexMap, cfg.raw.DisplayItemCountMax)
+	canonical, events := resolveReplyEvents(
+		reply,
+		loopResult.IndexMap,
+		loopResult.ReplyItemIDs,
+		cfg.raw.DisplayItemCountMax,
+		rankRuntime != nil,
+	)
 	if !loopResult.ReplyAlreadyEmitted {
 		if err := writer.EmitStep("reply"); err != nil {
 			return err

--- a/service/aishopping/reply_streamer.go
+++ b/service/aishopping/reply_streamer.go
@@ -7,9 +7,7 @@ import (
 
 type replyStreamer struct {
 	writer      *StreamWriter
-	indexMap    map[int]string
-	refIDs      []string
-	refPos      int
+	resolver    *replyMarkerResolver
 	maxItems    int
 	used        int
 	buffer      string
@@ -22,11 +20,10 @@ type markerTextState struct {
 	pendingHorizontal string
 }
 
-func newReplyStreamer(writer *StreamWriter, indexMap map[int]string, maxItems int) *replyStreamer {
+func newReplyStreamer(writer *StreamWriter, indexMap map[int]string, replyItemIDs []string, maxItems int, strictRankOrder bool) *replyStreamer {
 	return &replyStreamer{
 		writer:      writer,
-		indexMap:    indexMap,
-		refIDs:      orderedItemIDs(indexMap, maxItems),
+		resolver:    newReplyMarkerResolver(indexMap, replyItemIDs, maxItems, strictRankOrder),
 		maxItems:    maxItems,
 		seenItemIDs: make(map[string]struct{}),
 	}
@@ -69,12 +66,7 @@ func (s *replyStreamer) flush(final bool) error {
 			continue
 		}
 		if strings.HasPrefix(s.buffer, "[ref]") {
-			itemID := ""
-			if s.refPos < len(s.refIDs) && s.used < s.maxItems {
-				itemID = s.refIDs[s.refPos]
-			}
-			s.refPos++
-			if err := s.emitMarker(itemID); err != nil {
+			if err := s.emitMarker(s.resolver.nextRef()); err != nil {
 				return err
 			}
 			s.buffer = s.buffer[len("[ref]"):]
@@ -96,7 +88,7 @@ func (s *replyStreamer) flush(final bool) error {
 		if isIndexMarker(inner) {
 			index, err := strconv.Atoi(inner)
 			if err == nil {
-				if err := s.emitMarker(s.indexMap[index]); err != nil {
+				if err := s.emitMarker(s.resolver.resolveIndex(index)); err != nil {
 					return err
 				}
 			}

--- a/service/aishopping/types.go
+++ b/service/aishopping/types.go
@@ -12,8 +12,28 @@ type Request struct {
 	Uid              string
 	Language         string
 	UserText         string
+	Features         map[string]interface{}
 	EnableSuggestion bool
 	Config           *recconf.RecommendConfig
+}
+
+func (r *Request) GetParameter(name string) interface{} {
+	switch name {
+	case "scene", "scene_id":
+		return r.SceneId
+	case "session_id":
+		return r.SessionId
+	case "uid":
+		return r.Uid
+	case "language":
+		return r.Language
+	case "features":
+		return r.Features
+	case "category":
+		return "default"
+	default:
+		return nil
+	}
 }
 
 type SessionBlob struct {

--- a/sort/traffic_control_sort.go
+++ b/sort/traffic_control_sort.go
@@ -42,6 +42,21 @@ var tanhTable []float64
 var sigmoidTable []float64
 var experimentClient *experiments.ExperimentClient
 
+// TrafficControlHitsProperty is the item property holding the traffic control tasks
+// and targets that actually adjusted the position of the item, rendered as
+// "taskId1:targetId1,targetId2|taskId2:targetId3". It is always set (an empty string
+// when no task took effect), so it can be exposed as a required output field through
+// SceneConfs.OutputFields with "item:traffic_control_hits".
+const TrafficControlHitsProperty = "traffic_control_hits"
+
+// macroControl and microControl traverse the same items concurrently, so each writes
+// the tasks and targets it hits to its own property key, as a map of task id to target
+// ids. Sort merges them once both finish.
+const (
+	macroTrafficControlHitsProperty = "__macro_traffic_control_hits__"
+	microTrafficControlHitsProperty = "__micro_traffic_control_hits__"
+)
+
 func init() {
 	positionWeight = make([]float64, 500)
 	for i := 0; i < 500; i++ {
@@ -115,6 +130,8 @@ func (p *TrafficControlSort) Sort(sortData *SortData) error {
 	for i, item := range items {
 		item.AddProperty("__traffic_control_id__", i+1)
 		item.AddProperty("_ORIGIN_POSITION_", i+1)
+		// default to an empty string so items hit by no task still return the field
+		item.AddProperty(TrafficControlHitsProperty, "")
 	}
 
 	// 如果服务启动时，没有加载成功，这里再次尝试
@@ -158,6 +175,7 @@ func (p *TrafficControlSort) Sort(sortData *SortData) error {
 	//	candidateCount = 0
 	//}
 	for i, item := range items {
+		mergeTrafficControlHits(item)
 		finalDeltaRank := item.GetAlgoScore("__delta_rank__")
 		if finalDeltaRank != 0.0 {
 			rank := float64(i+1) - finalDeltaRank
@@ -332,6 +350,7 @@ func macroControl(ctx *context.RecommendContext, controllerMap map[string]*PIDCo
 			for idx, item := range items {
 				i := b + idx
 				finalDeltaRank := 0.0
+				var hitTargets map[string][]string
 				for targetId, controller := range controllerMap {
 					if !isControlledItem(controller, item) {
 						if ctx.Debug {
@@ -344,6 +363,13 @@ func macroControl(ctx *context.RecommendContext, controllerMap map[string]*PIDCo
 					if alpha, ok := targetAlphaMap[targetId]; ok && alpha != 0 {
 						deltaRank := computeDeltaRank(controller, item, i, alpha, ctrlParams, ctx)
 						finalDeltaRank += deltaRank // 形成合力
+						if deltaRank != 0.0 {
+							if hitTargets == nil {
+								hitTargets = make(map[string][]string, len(controllerMap))
+							}
+							taskId := controller.task.TrafficControlTaskId
+							hitTargets[taskId] = append(hitTargets[taskId], targetId)
+						}
 					}
 				}
 
@@ -352,6 +378,10 @@ func macroControl(ctx *context.RecommendContext, controllerMap map[string]*PIDCo
 					controlId, _ := item.IntProperty("__traffic_control_id__")
 					if controlId == 0 && finalDeltaRank < 1.0 {
 						item.AddProperty("__traffic_control_id__", item.GetProperty("_ORIGIN_POSITION_"))
+					}
+					// only record when the delta rank is really applied to the item
+					if len(hitTargets) > 0 {
+						item.AddProperty(macroTrafficControlHitsProperty, hitTargets)
 					}
 				}
 			}
@@ -646,6 +676,7 @@ func microControl(ctx *context.RecommendContext, controllerMap map[string]*PIDCo
 			for j, item := range items {
 				i := begin + j
 				deltaRank := 0.0
+				var hitTargets map[string][]string
 				for targetId, controller := range controllerMap {
 					if !isControlledItem(controller, item) {
 						ctx.LogDebug(fmt.Sprintf("item id:%v is not controller", item.Id))
@@ -675,6 +706,13 @@ func microControl(ctx *context.RecommendContext, controllerMap map[string]*PIDCo
 						}
 					}
 					deltaRank += delta // 多个目标调控方向不一致时，需要扳手腕看谁力气大
+					if delta != 0.0 {
+						if hitTargets == nil {
+							hitTargets = make(map[string][]string, len(controllerMap))
+						}
+						taskId := controller.task.TrafficControlTaskId
+						hitTargets[taskId] = append(hitTargets[taskId], targetId)
+					}
 					if ctx.Debug {
 						ctx.LogDebug(fmt.Sprintf("module=TrafficControlSort\t[targetId:%s/targetName:%s], itemId:%s,origiPosition=%d, aimValue=%f, alpha=%f, deltaRank=%f", targetId, controller.target.Name, item.Id, originPosition, aimValue, alpha, delta))
 					}
@@ -683,8 +721,13 @@ func microControl(ctx *context.RecommendContext, controllerMap map[string]*PIDCo
 					if ctx.Debug {
 						ctx.LogDebug(fmt.Sprintf("module=TrafficControlSort\titem:%v\tfinal delta rank:%v", item.Id, deltaRank))
 					}
+					// only record when the delta rank is really applied to the item, the uplift
+					// branch can be skipped once the limit count is reached
 					if deltaRank < 0 {
 						item.IncrAlgoScore("__delta_rank__", deltaRank)
+						if len(hitTargets) > 0 {
+							item.AddProperty(microTrafficControlHitsProperty, hitTargets)
+						}
 					} else if upliftCount < limitCount { // uplift
 						item.IncrAlgoScore("__delta_rank__", deltaRank)
 						countMu.Lock()
@@ -693,6 +736,9 @@ func microControl(ctx *context.RecommendContext, controllerMap map[string]*PIDCo
 						pos, _ := item.IntProperty("_ORIGIN_POSITION_")
 						if pos > ctx.Size {
 							item.AddProperty("__traffic_control_id__", 0)
+						}
+						if len(hitTargets) > 0 {
+							item.AddProperty(microTrafficControlHitsProperty, hitTargets)
 						}
 					}
 				}
@@ -913,6 +959,75 @@ func isControlledItem(controller *PIDController, item *module.Item) bool {
 	}
 
 	return ToBool(result, false)
+}
+
+// lessTrafficControlId orders ids numerically when both of them are numeric, so the
+// rendered output keeps a natural order, and falls back to a lexicographic order to
+// stay deterministic for any other id format.
+func lessTrafficControlId(a, b string) bool {
+	ai, aErr := strconv.ParseInt(a, 10, 64)
+	bi, bErr := strconv.ParseInt(b, 10, 64)
+	if aErr == nil && bErr == nil {
+		return ai < bi
+	}
+	return a < b
+}
+
+// formatTrafficControlHits renders the hit tasks and their targets as
+// "taskId1:targetId1,targetId2|taskId2:targetId3". Both task ids and target ids are
+// ordered so that the output stays stable across requests.
+func formatTrafficControlHits(hits map[string][]string) string {
+	if len(hits) == 0 {
+		return ""
+	}
+	taskIds := make([]string, 0, len(hits))
+	for taskId := range hits {
+		taskIds = append(taskIds, taskId)
+	}
+	sort.Slice(taskIds, func(i, j int) bool { return lessTrafficControlId(taskIds[i], taskIds[j]) })
+
+	var sb strings.Builder
+	for i, taskId := range taskIds {
+		if i > 0 {
+			sb.WriteByte('|')
+		}
+		sb.WriteString(taskId)
+		sb.WriteByte(':')
+		targetIds := hits[taskId]
+		sort.Slice(targetIds, func(i, j int) bool { return lessTrafficControlId(targetIds[i], targetIds[j]) })
+		for j, targetId := range targetIds {
+			if j > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString(targetId)
+		}
+	}
+	return sb.String()
+}
+
+// mergeTrafficControlHits merges the hits collected by macroControl and microControl
+// into the final output property. It must be called after both controls finished, so it
+// runs free of their concurrent writes.
+func mergeTrafficControlHits(item *module.Item) {
+	macroHits, _ := item.GetProperty(macroTrafficControlHitsProperty).(map[string][]string)
+	microHits, _ := item.GetProperty(microTrafficControlHitsProperty).(map[string][]string)
+	if len(macroHits) == 0 && len(microHits) == 0 {
+		return
+	}
+	item.DeleteProperty(macroTrafficControlHitsProperty)
+	item.DeleteProperty(microTrafficControlHitsProperty)
+
+	hits := make(map[string][]string, len(macroHits)+len(microHits))
+	for _, source := range []map[string][]string{macroHits, microHits} {
+		for taskId, targetIds := range source {
+			for _, targetId := range targetIds {
+				if !isItemInArray(targetId, hits[taskId]) {
+					hits[taskId] = append(hits[taskId], targetId)
+				}
+			}
+		}
+	}
+	item.AddProperty(TrafficControlHitsProperty, formatTrafficControlHits(hits))
 }
 
 type ItemRankSlice []*module.Item

--- a/web/chat_controller.go
+++ b/web/chat_controller.go
@@ -15,12 +15,13 @@ import (
 )
 
 type ChatParam struct {
-	SceneId          string      `json:"scene_id"`
-	SessionId        string      `json:"session_id"`
-	InputMessage     ChatMessage `json:"input_message"`
-	Uid              string      `json:"uid"`
-	Language         string      `json:"language"`
-	EnableSuggestion bool        `json:"enable_suggestion"`
+	SceneId          string                 `json:"scene_id"`
+	SessionId        string                 `json:"session_id"`
+	InputMessage     ChatMessage            `json:"input_message"`
+	Uid              string                 `json:"uid"`
+	Language         string                 `json:"language"`
+	Features         map[string]interface{} `json:"features,omitempty"`
+	EnableSuggestion bool                   `json:"enable_suggestion"`
 }
 
 type ChatMessage struct {
@@ -93,6 +94,7 @@ func (c *ChatController) Process(w http.ResponseWriter, r *http.Request) {
 		Uid:              c.param.Uid,
 		Language:         c.param.Language,
 		UserText:         c.userText,
+		Features:         c.param.Features,
 		EnableSuggestion: c.param.EnableSuggestion,
 		Config:           recconf.Config,
 	}


### PR DESCRIPTION
## Summary
- merge the latest master changes into the AI shopping feature branch
- add optional AI shopping fine-rank configuration using the existing Rank/EAS pipeline
- rank and truncate recalled goods before citation indexes and suggestion snapshots are generated
- instruct the reply model to summarize products in server-ranked order
- fail open to the original recall order when fine ranking fails

## Scope
- no client, SSE, citation, session, or suggestion protocol changes
- no new tests, evaluation, shadow, metrics, or rollout logic

## Verification
- gofmt on changed Go files
- git diff --check
- GOCACHE=/private/tmp/pairec-go-build-cache go build ./service/aishopping