### PR TITLE
feat: align recommend API with feed contract

### DIFF
--- a/pairec.go
+++ b/pairec.go
@@ -148,6 +148,7 @@ func registerRouteInfo() {
 			if p == "/ping" ||
 				p == "/route_paths" ||
 				p == "/api/recommend" ||
+				p == "/api/rec/feed" ||
 				p == "/api/recall" ||
 				p == "/api/feature_reply" ||
 				p == "/metrics" ||
@@ -166,6 +167,7 @@ func registerRouteInfo() {
 
 	// register recommend Controller
 	Route("/api/recommend", &web.RecommendController{})
+	Route("/api/rec/feed", &web.RecommendController{})
 	Route("/api/recall", &web.UserRecallController{})
 	Route("/api/callback", &web.CallBackController{})
 	Route("/api/feature_reply", &web.FeatureReplyController{})

--- a/pairec_route_test.go
+++ b/pairec_route_test.go
@@ -1,0 +1,24 @@
+package pairec
+
+import (
+	"testing"
+
+	"github.com/alibaba/pairec/v2/web"
+)
+
+func TestRecommendRoutesUseRecommendController(t *testing.T) {
+	previous := PairecApp
+	PairecApp = NewApp()
+	t.Cleanup(func() { PairecApp = previous })
+	registerRouteInfo()
+
+	for _, path := range []string{"/api/recommend", "/api/rec/feed"} {
+		info, exists := PairecApp.Handlers.routeInfos[path]
+		if !exists {
+			t.Fatalf("route %s is not registered", path)
+		}
+		if _, ok := info.initialize().(*web.RecommendController); !ok {
+			t.Fatalf("route %s does not use RecommendController", path)
+		}
+	}
+}

--- a/web/recommend_controller.go
+++ b/web/recommend_controller.go
@@ -22,12 +22,13 @@ const (
 )
 
 type RecommendParam struct {
-	SceneId  string                 `json:"scene_id"`
-	Category string                 `json:"category"`
-	Uid      string                 `json:"uid"`  // user id
-	Size     int                    `json:"size"` // get recommend items size
-	Debug    bool                   `json:"debug"`
-	Features map[string]interface{} `json:"features"`
+	SceneId   string                 `json:"scene_id"`
+	Category  string                 `json:"category"`
+	Uid       string                 `json:"uid"`  // user id
+	Size      int                    `json:"size"` // get recommend items size
+	Debug     bool                   `json:"debug"`
+	Features  map[string]interface{} `json:"features"`
+	RequestId string                 `json:"request_id"`
 }
 
 func (r *RecommendParam) GetParameter(name string) interface{} {
@@ -53,9 +54,10 @@ type RecommendResponse struct {
 	Items []*ItemData `json:"items"`
 }
 type ItemData struct {
-	ItemId     string `json:"item_id"`
-	ItemType   string `json:"item_type"`
-	RetrieveId string `json:"retrieve_id"`
+	ItemId     string  `json:"item_id"`
+	ItemType   string  `json:"item_type"`
+	Score      float64 `json:"score"`
+	RetrieveId string  `json:"retrieve_id"`
 }
 
 func (r *RecommendResponse) ToString() string {
@@ -82,11 +84,11 @@ func (c *RecommendController) Process(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	c.RequestId = utils.UUID()
-	c.LogRequestBegin(r)
 	if err := c.CheckParameter(); err != nil {
 		c.SendError(w, ERROR_PARAMETER_CODE, err.Error())
 		return
 	}
+	c.LogRequestBegin(r)
 	c.doProcess(w, r)
 	c.End = time.Now()
 	c.LogRequestEnd(r)
@@ -94,6 +96,9 @@ func (c *RecommendController) Process(w http.ResponseWriter, r *http.Request) {
 func (r *RecommendController) CheckParameter() error {
 	if err := json.Unmarshal(r.RequestBody, &r.param); err != nil {
 		return err
+	}
+	if r.param.RequestId != "" {
+		r.RequestId = r.param.RequestId
 	}
 
 	if len(r.param.Uid) == 0 {
@@ -124,6 +129,7 @@ func (c *RecommendController) doProcess(w http.ResponseWriter, r *http.Request) 
 		idata := &ItemData{
 			ItemId:     string(item.Id),
 			ItemType:   item.ItemType,
+			Score:      item.Score,
 			RetrieveId: item.RetrieveId,
 		}
 

--- a/web/recommend_controller_test.go
+++ b/web/recommend_controller_test.go
@@ -1,0 +1,46 @@
+package web
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRecommendControllerUsesCallerRequestId(t *testing.T) {
+	controller := &RecommendController{
+		Controller: Controller{RequestId: "generated-request-id"},
+	}
+	controller.RequestBody = []byte(`{"uid":"user-1","request_id":"caller-request-id"}`)
+	if err := controller.CheckParameter(); err != nil {
+		t.Fatal(err)
+	}
+	if controller.RequestId != "caller-request-id" {
+		t.Fatalf("RequestId = %q, want caller-request-id", controller.RequestId)
+	}
+}
+
+func TestRecommendControllerKeepsGeneratedRequestId(t *testing.T) {
+	controller := &RecommendController{
+		Controller: Controller{RequestId: "generated-request-id"},
+	}
+	controller.RequestBody = []byte(`{"uid":"user-1"}`)
+	if err := controller.CheckParameter(); err != nil {
+		t.Fatal(err)
+	}
+	if controller.RequestId != "generated-request-id" {
+		t.Fatalf("RequestId = %q, want generated-request-id", controller.RequestId)
+	}
+}
+
+func TestItemDataIncludesScore(t *testing.T) {
+	contents, err := json.Marshal(ItemData{ItemId: "item-1", Score: 0.75})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value map[string]interface{}
+	if err := json.Unmarshal(contents, &value); err != nil {
+		t.Fatal(err)
+	}
+	if value["score"] != 0.75 {
+		t.Fatalf("score = %v, want 0.75", value["score"])
+	}
+}


### PR DESCRIPTION
## Summary

- register `/api/rec/feed` as an alias of the existing `RecommendController`
- include each recommended item's computed `score` in the response
- accept an optional caller `request_id`, while preserving UUID generation as the fallback
- use the effective request ID consistently in request logs, recommendation context, and responses
- add regression tests for both route registration and response/request fields

## Compatibility

The change is additive. Existing `/api/recommend` callers can continue omitting `request_id`. Both paths use the same controller and response model.

## Validation

```text
go test . ./web
go vet . ./web
```

Both commands pass.

`go test ./...` was also run. The repository's existing integration-dependent tests still fail when EAS endpoints, OpenSearch credentials, Redis, and TensorFlow Serving are unavailable; the root and `web` packages affected by this PR pass.

Closes #238
