### PR TITLE
fix: preserve valid shopping results and strict FeatureStore lookup

### DIFF
--- a/algorithm/aichat/tool_schema.go
+++ b/algorithm/aichat/tool_schema.go
@@ -109,12 +109,7 @@ func FieldAwareSearchGoodsTool(knowledgeCandidateIDs []string) Tool {
 	}
 }
 
-const (
-	SuggestionMinLength = 2
-	SuggestionMaxLength = 80
-)
-
-func SuggestionTool(count int) Tool {
+func SuggestionTool(count, minLength, maxLength int) Tool {
 	return Tool{
 		Type: "function",
 		Function: ToolFunction{
@@ -129,8 +124,8 @@ func SuggestionTool(count int) Tool {
 						"maxItems": count,
 						"items": map[string]interface{}{
 							"type":      "string",
-							"minLength": SuggestionMinLength,
-							"maxLength": SuggestionMaxLength,
+							"minLength": minLength,
+							"maxLength": maxLength,
 						},
 					},
 				},

--- a/algorithm/aichat/tool_schema.go
+++ b/algorithm/aichat/tool_schema.go
@@ -109,6 +109,11 @@ func FieldAwareSearchGoodsTool(knowledgeCandidateIDs []string) Tool {
 	}
 }
 
+const (
+	SuggestionMinLength = 2
+	SuggestionMaxLength = 80
+)
+
 func SuggestionTool(count int) Tool {
 	return Tool{
 		Type: "function",
@@ -124,8 +129,8 @@ func SuggestionTool(count int) Tool {
 						"maxItems": count,
 						"items": map[string]interface{}{
 							"type":      "string",
-							"minLength": 1,
-							"maxLength": 160,
+							"minLength": SuggestionMinLength,
+							"maxLength": SuggestionMaxLength,
 						},
 					},
 				},

--- a/persist/fs/featurestore.go
+++ b/persist/fs/featurestore.go
@@ -22,20 +22,7 @@ func GetFeatureStoreClient(name string) (*FSClient, error) {
 	if client, ok := fsInstances[name]; ok {
 		return client, nil
 	}
-	var matched *FSClient
-	for _, client := range fsInstances {
-		if client.projectName != name {
-			continue
-		}
-		if matched != nil {
-			return nil, fmt.Errorf("multiple feature store clients found for project:%s", name)
-		}
-		matched = client
-	}
-	if matched == nil {
-		return nil, fmt.Errorf("feature store client not found, name or project:%s", name)
-	}
-	return matched, nil
+	return nil, fmt.Errorf("feature store client not found, name:%s", name)
 }
 
 type FSClient struct {

--- a/persist/fs/featurestore_test.go
+++ b/persist/fs/featurestore_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aliyun/aliyun-pai-featurestore-go-sdk/v2/domain"
 )
 
+// Run with go test -race ./persist/fs to detect unsynchronized project access.
 func TestFSClientProjectAccessIsSynchronized(t *testing.T) {
 	client := &FSClient{project: &domain.Project{}}
 	projects := []*domain.Project{{}, {}}
@@ -29,4 +30,40 @@ func TestFSClientProjectAccessIsSynchronized(t *testing.T) {
 		}
 	}()
 	wg.Wait()
+}
+
+func TestGetFeatureStoreClientUsesConfigKey(t *testing.T) {
+	first := &FSClient{projectName: "b"}
+	second := &FSClient{projectName: "shared"}
+	third := &FSClient{projectName: "shared"}
+	projectOnly := &FSClient{projectName: "project-only"}
+	fsInstancesMu.Lock()
+	original := fsInstances
+	fsInstances = map[string]*FSClient{"a": first, "b": second, "c": third, "d": projectOnly}
+	fsInstancesMu.Unlock()
+	t.Cleanup(func() {
+		fsInstancesMu.Lock()
+		fsInstances = original
+		fsInstancesMu.Unlock()
+	})
+
+	for _, test := range []struct {
+		name string
+		key  string
+		want *FSClient
+	}{
+		{name: "key only", key: "a", want: first},
+		{name: "key wins over another project", key: "b", want: second},
+		{name: "same project retains separate keys", key: "c", want: third},
+		{name: "project only is not a key", key: "project-only"},
+		{name: "shared project is not a key", key: "shared"},
+		{name: "missing key and project", key: "missing"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := GetFeatureStoreClient(test.key)
+			if got != test.want || (err != nil) != (test.want == nil) {
+				t.Fatalf("GetFeatureStoreClient(%q) = %p, %v; want %p, error=%t", test.key, got, err, test.want, test.want == nil)
+			}
+		})
+	}
 }

--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -845,6 +845,8 @@ type SuggestionConfig struct {
 	RecallName      string
 	LLMAlgoName     string
 	PromptTemplates map[string]string
+	MinLength       int // Unicode characters; zero defaults to 2.
+	MaxLength       int // Unicode characters; zero defaults to 80.
 }
 
 type FallbackConfig struct {

--- a/service/recall/ha3_chat_multi_field.go
+++ b/service/recall/ha3_chat_multi_field.go
@@ -206,9 +206,6 @@ func (r *Ha3ChatRecall) searchMultiFieldFallback(ctx context.Context, req Search
 		}(index, route)
 	}
 	wg.Wait()
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
 
 	successCount := 0
 	errors := make([]string, 0, len(results))
@@ -250,6 +247,9 @@ func (r *Ha3ChatRecall) searchFieldWithRetry(ctx context.Context, field string, 
 			break
 		}
 		delay := multiFieldRetryDelay(attempt)
+		if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= delay {
+			break
+		}
 		timer := time.NewTimer(delay)
 		select {
 		case <-ctx.Done():
@@ -279,11 +279,11 @@ func retryableHa3SearchError(err error) bool {
 }
 
 func multiFieldRetryDelay(attempt int) time.Duration {
-	base := time.Second << (attempt - 1)
-	maxJitter := base / 4
-	if maxJitter > 500*time.Millisecond {
-		maxJitter = 500 * time.Millisecond
+	base := 100 * time.Millisecond << (attempt - 1)
+	if base > 400*time.Millisecond {
+		base = 400 * time.Millisecond
 	}
+	maxJitter := base / 4
 	jitter := time.Duration(rand.Int63n(int64(maxJitter) + 1))
 	return base + jitter
 }

--- a/service/recall/ha3_chat_recall.go
+++ b/service/recall/ha3_chat_recall.go
@@ -95,6 +95,7 @@ func (r *Ha3ChatRecall) GetCandidateItems(user *module.User, context *pairecctx.
 func (r *Ha3ChatRecall) Search(ctx context.Context, req SearchGoodsRequest) (*SearchGoodsResult, error) {
 	fieldAware := req.MultiFieldFallback && r.fieldAwareEnabled()
 	req.MultiFieldFallback = fieldAware
+	searchCtx := ctx
 	var err error
 	if fieldAware {
 		req, err = normalizeFieldAwareRequest(req)
@@ -104,22 +105,26 @@ func (r *Ha3ChatRecall) Search(ctx context.Context, req SearchGoodsRequest) (*Se
 		if req.Limit <= 0 {
 			return nil, fmt.Errorf("limit must be positive")
 		}
-		searchCtx, cancel := context.WithTimeout(ctx, fieldAwareSearchTimeout)
+		var cancel context.CancelFunc
+		searchCtx, cancel = context.WithTimeout(ctx, fieldAwareSearchTimeout)
 		defer cancel()
-		ctx = searchCtx
 	}
 	search := r.searchField
 	if fieldAware {
 		search = r.searchFieldWithRetry
 	}
-	result, err := search(ctx, r.conf.DefaultField, req.Keywords, req.Operator, req, req.Limit)
+	result, err := search(searchCtx, r.conf.DefaultField, req.Keywords, req.Operator, req, req.Limit)
 	if err != nil {
 		return nil, err
 	}
 	if len(result.Hits) > 0 || !fieldAware {
 		return result, nil
 	}
-	return r.searchMultiFieldFallback(ctx, req)
+	result, err = r.searchMultiFieldFallback(searchCtx, req)
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return result, err
 }
 
 func (r *Ha3ChatRecall) searchField(ctx context.Context, field string, keywords []string, operator string, req SearchGoodsRequest, hit int) (*SearchGoodsResult, error) {
@@ -154,10 +159,34 @@ func (r *Ha3ChatRecall) searchField(ctx context.Context, field string, keywords 
 	if err != nil {
 		return nil, err
 	}
+	runtime := r.client.Runtime()
+	if req.MultiFieldFallback {
+		// Tea's HTTP timeout is connect + read. Bound both without mutating
+		// the shared runtime or changing the legacy search path.
+		if deadline, ok := ctx.Deadline(); ok {
+			remaining := int(time.Until(deadline) / time.Millisecond)
+			if remaining < 2 {
+				return nil, context.DeadlineExceeded
+			}
+			bounded := *runtime
+			connect := tea.IntValue(bounded.ConnectTimeout)
+			if connect <= 0 || connect > remaining/2 {
+				connect = remaining / 2
+			}
+			read := tea.IntValue(bounded.ReadTimeout)
+			if read <= 0 || read > remaining-connect {
+				read = remaining - connect
+			}
+			bounded.ConnectTimeout = tea.Int(connect)
+			bounded.ReadTimeout = tea.Int(read)
+			bounded.Autoretry = tea.Bool(false)
+			runtime = &bounded
+		}
+	}
 	resp, err := r.client.Ha3Client.SearchRestWithOptions(
 		tea.String(r.conf.IndexName),
 		(&ha3client.SearchRequestModel{}).SetHeaders(map[string]*string{}).SetBody(string(bodyBytes)),
-		r.client.Runtime(),
+		runtime,
 	)
 	if ctxErr := ctx.Err(); ctxErr != nil {
 		return nil, ctxErr
@@ -270,13 +299,9 @@ func sanitizeSearchKeyword(keyword string) string {
 }
 
 func parseHa3ChatResponse(resp *ha3client.SearchResponseModel) (*SearchGoodsResult, error) {
-	total, items, responseErrors, err := decodeHa3ChatResponse(resp)
+	total, items, _, err := decodeHa3ChatResponse(resp)
 	if err != nil {
 		return nil, err
-	}
-	if hasHa3ResponseErrors(responseErrors) {
-		payload, _ := json.Marshal(responseErrors)
-		return nil, fmt.Errorf("ha3 search errors: %s", payload)
 	}
 	hits := make([]GoodsHit, 0, len(items))
 	for index, item := range items {

--- a/service/searchsuggestion/config.go
+++ b/service/searchsuggestion/config.go
@@ -11,13 +11,20 @@ import (
 	recallsvc "github.com/alibaba/pairec/v2/service/recall"
 )
 
+const (
+	defaultMinLength = 2
+	defaultMaxLength = 80
+)
+
 type KnowledgeRecall interface {
 	SearchKnowledge(context.Context, string) (*recallsvc.KnowledgeSearchResult, error)
 }
 
 type RuntimeConfig struct {
-	Prompt string
-	Model  *aichat.Model
+	Prompt    string
+	Model     *aichat.Model
+	MinLength int
+	MaxLength int
 }
 
 func ResolveGenerator(config *recconf.RecommendConfig, sceneID, language string) (*RuntimeConfig, *Error) {
@@ -40,7 +47,12 @@ func ResolveGenerator(config *recconf.RecommendConfig, sceneID, language string)
 	if !ok {
 		return nil, NewError(CodeModelUnavailable, false, fmt.Errorf("algorithm %q is not PAI_CHAT", suggestionConfig.LLMAlgoName))
 	}
-	return &RuntimeConfig{Prompt: prompt, Model: model}, nil
+	return &RuntimeConfig{
+		Prompt:    prompt,
+		Model:     model,
+		MinLength: suggestionConfig.MinLength,
+		MaxLength: suggestionConfig.MaxLength,
+	}, nil
 }
 
 func ResolveStandalone(config *recconf.RecommendConfig, sceneID, language string) (*RuntimeConfig, KnowledgeRecall, *Error) {
@@ -89,6 +101,15 @@ func findConfig(config *recconf.RecommendConfig, sceneID string) (*recconf.Sugge
 	}
 	if strings.TrimSpace(cloned.LLMAlgoName) == "" {
 		return nil, fmt.Errorf("SuggestionConfig.LLMAlgoName is empty")
+	}
+	if cloned.MinLength == 0 {
+		cloned.MinLength = defaultMinLength
+	}
+	if cloned.MaxLength == 0 {
+		cloned.MaxLength = defaultMaxLength
+	}
+	if cloned.MinLength < 1 || cloned.MaxLength < cloned.MinLength {
+		return nil, fmt.Errorf("SuggestionConfig requires 1 <= MinLength <= MaxLength, got %d and %d", cloned.MinLength, cloned.MaxLength)
 	}
 	return &cloned, nil
 }

--- a/service/searchsuggestion/generator.go
+++ b/service/searchsuggestion/generator.go
@@ -30,7 +30,7 @@ func Generate(ctx context.Context, runtimeConfig *RuntimeConfig, input *Generati
 			{Role: "system", Content: runtimeConfig.Prompt},
 			{Role: "user", Content: "UNTRUSTED_SUGGESTION_CONTEXT_JSON:\n" + string(payload)},
 		},
-		Tools: []aichat.Tool{aichat.SuggestionTool(input.SuggestionCount)},
+		Tools: []aichat.Tool{aichat.SuggestionTool(input.SuggestionCount, runtimeConfig.MinLength, runtimeConfig.MaxLength)},
 		ToolChoice: map[string]interface{}{
 			"type":     "function",
 			"function": map[string]string{"name": "emit_suggestions"},
@@ -52,7 +52,7 @@ func Generate(ctx context.Context, runtimeConfig *RuntimeConfig, input *Generati
 	if parseErr != nil {
 		return Outcome{Err: parseErr}
 	}
-	validated, validationErr := Validate(suggestions, input.SuggestionCount, input.CurrentQuery)
+	validated, validationErr := Validate(suggestions, input.SuggestionCount, input.CurrentQuery, runtimeConfig.MinLength, runtimeConfig.MaxLength)
 	if validationErr != nil {
 		return Outcome{Err: validationErr}
 	}

--- a/service/searchsuggestion/validator.go
+++ b/service/searchsuggestion/validator.go
@@ -7,7 +7,6 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/alibaba/pairec/v2/algorithm/aichat"
 	"github.com/alibaba/pairec/v2/log"
 	"golang.org/x/text/unicode/norm"
 )
@@ -18,7 +17,7 @@ var (
 	markdownPattern = regexp.MustCompile("(?m)(^\\s{0,3}(#{1,6}|[-*+]\\s|>\\s)|```|`|\\[[^]]*\\]\\([^)]*\\))")
 )
 
-func Validate(suggestions []string, count int, currentQuery string) ([]string, *Error) {
+func Validate(suggestions []string, count int, currentQuery string, minLength, maxLength int) ([]string, *Error) {
 	if len(suggestions) != count {
 		return nil, NewError(CodeValidationFailed, true, fmt.Errorf("expected %d suggestions, got %d", count, len(suggestions)))
 	}
@@ -32,7 +31,7 @@ func Validate(suggestions []string, count int, currentQuery string) ([]string, *
 		_, duplicate := seen[normalized]
 		reason := ""
 		switch {
-		case length < aichat.SuggestionMinLength || length > aichat.SuggestionMaxLength:
+		case length < minLength || length > maxLength:
 			reason = "length"
 		case strings.IndexFunc(suggestion, unicode.IsControl) >= 0:
 			reason = "control"

--- a/service/searchsuggestion/validator.go
+++ b/service/searchsuggestion/validator.go
@@ -7,12 +7,14 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/alibaba/pairec/v2/algorithm/aichat"
+	"github.com/alibaba/pairec/v2/log"
 	"golang.org/x/text/unicode/norm"
 )
 
 var (
 	urlPattern      = regexp.MustCompile(`(?i)(https?://|www\.|\b[a-z0-9.-]+\.(com|cn|net|org)\b)`)
-	internalPattern = regexp.MustCompile(`(?i)(item[_ -]?id|knowledge[_ -]?id|candidate[_ -]?id|search_goods|emit_suggestions|\bprompt\b|\btool\b|citation|\bK[0-9]+\b|\[[0-9]+\]|【[0-9]+】)`)
+	internalPattern = regexp.MustCompile(`(?i)(item[_ -]?id|knowledge[_ -]?id|candidate[_ -]?id|search_goods|emit_suggestions|\[\[citation:|\[[0-9]+\]|【[0-9]+】)`)
 	markdownPattern = regexp.MustCompile("(?m)(^\\s{0,3}(#{1,6}|[-*+]\\s|>\\s)|```|`|\\[[^]]*\\]\\([^)]*\\))")
 )
 
@@ -26,27 +28,34 @@ func Validate(suggestions []string, count int, currentQuery string) ([]string, *
 	for _, suggestion := range suggestions {
 		suggestion = strings.TrimSpace(norm.NFKC.String(suggestion))
 		length := utf8.RuneCountInString(suggestion)
-		if length < 4 || length > 80 {
-			return nil, NewError(CodeValidationFailed, true, fmt.Errorf("suggestion length out of range"))
-		}
-		for _, r := range suggestion {
-			if r == '\n' || r == '\r' || unicode.IsControl(r) {
-				return nil, NewError(CodeValidationFailed, true, fmt.Errorf("suggestion contains control characters"))
-			}
-		}
-		if urlPattern.MatchString(suggestion) || internalPattern.MatchString(suggestion) || markdownPattern.MatchString(suggestion) ||
-			strings.ContainsAny(suggestion, "{}<>") {
-			return nil, NewError(CodeValidationFailed, true, fmt.Errorf("suggestion contains forbidden syntax"))
-		}
 		normalized := normalizeComparable(suggestion)
-		if normalized == "" || (baseline != "" && normalized == baseline) {
-			return nil, NewError(CodeValidationFailed, true, fmt.Errorf("suggestion repeats current query"))
+		_, duplicate := seen[normalized]
+		reason := ""
+		switch {
+		case length < aichat.SuggestionMinLength || length > aichat.SuggestionMaxLength:
+			reason = "length"
+		case strings.IndexFunc(suggestion, unicode.IsControl) >= 0:
+			reason = "control"
+		case urlPattern.MatchString(suggestion):
+			reason = "url"
+		case internalPattern.MatchString(suggestion):
+			reason = "internal_marker"
+		case markdownPattern.MatchString(suggestion) || strings.ContainsAny(suggestion, "{}<>"):
+			reason = "markup"
+		case normalized == "" || (baseline != "" && normalized == baseline):
+			reason = "repeated_query"
+		case duplicate:
+			reason = "duplicate"
 		}
-		if _, exists := seen[normalized]; exists {
-			return nil, NewError(CodeValidationFailed, true, fmt.Errorf("duplicate suggestions"))
+		if reason != "" {
+			log.Warning(fmt.Sprintf("module=SearchSuggestion\tevent=filtered\treason=%s", reason))
+			continue
 		}
 		seen[normalized] = struct{}{}
 		validated = append(validated, suggestion)
+	}
+	if len(validated) == 0 {
+		return nil, NewError(CodeValidationFailed, true, fmt.Errorf("no valid suggestions"))
 	}
 	return validated, nil
 }


### PR DESCRIPTION
This follow-up to #225 preserves valid shopping suggestions and successful recall results, and restores FeatureStore lookup by configuration key.

## Changes

- Allow ordinary shopping words and model names such as `gardening tool set` and `K2 skis`; filter invalid or duplicate suggestions individually. Keep the model candidate count strict. Make suggestion length configurable through `SuggestionConfig.MinLength` and `MaxLength`, defaulting to 2–80 Unicode characters, and share the resolved limits with the tool schema and validator.
- Restore exact FeatureStore configuration-key lookup while retaining synchronization. Add six table-driven lookup cases and document the existing concurrency test's `-race` requirement.
- Use short, capped HA3 retry delays and bound request-local connection/read timeouts by the remaining field-aware budget. Preserve successful fallback routes when another route fails; propagate parent cancellation.
- Restore legacy HA3 handling of responses containing errors and valid hits; keep configured parsing strict.

Strict citation mapping and EAS ranking behavior are unchanged.

## Validation

- Passed `go test -race -count=1 ./persist/fs`.
- Passed `go build ./...`.
- Passed `go vet ./algorithm/aichat ./persist/fs ./service/searchsuggestion ./service/recall`.
- Passed `go vet ./algorithm/aichat ./service/searchsuggestion ./service/aishopping ./recconf` after adding configurable suggestion lengths.

## Configuration and limits

`Ha3KnowledgeVectorConf.FeatureStoreName` must name a key in `FeatureStoreConfs`, not a project name.

In the existing scene's `SuggestionConfig`, set `MinLength` and `MaxLength` to override suggestion length bounds. Omitted or zero values use defaults of 2 and 80 respectively; resolved values must satisfy `1 <= MinLength <= MaxLength`. Both embedded and standalone suggestions use these bounds. Align any explicit length instructions in external prompts with the configured values. No private configuration or credentials are included.

The Tea SDK does not accept the parent context; transport timeouts bound the active call, but parent cancellation does not interrupt it immediately.
