### PR TITLE
fix embedding sort bug

### DIFF
--- a/recconf/recconf.go
+++ b/recconf/recconf.go
@@ -1053,6 +1053,7 @@ type DPPSortConfig struct {
 	EmbeddingSeparator string
 	Alpha              float64
 	CacheTimeInMinutes int
+	CacheSize          int
 	EmbeddingHookNames []string
 	NormalizeEmb       string
 	WindowSize         int
@@ -1074,6 +1075,7 @@ type SSDSortConfig struct {
 	Gamma              float64
 	UseSSDStar         bool
 	CacheTimeInMinutes int
+	CacheSize          int
 	NormalizeEmb       string
 	WindowSize         int
 	AbortRunCount      int

--- a/sort/dpp_sort.go
+++ b/sort/dpp_sort.go
@@ -57,6 +57,15 @@ func RegisterEmbeddingHook(name string, fn EmbeddingHookFunc) {
 	embeddingHooks[name] = fn
 }
 
+// cloneEmbedding 返回 embCache 中向量的副本。DPP/SSD 的打散过程会对 item.Embedding 做原地运算
+// (floats.Scale/Sub/Add), 若直接引用缓存里的 slice, 会把结果写回缓存, 污染后续其他请求。
+// cap 多预留一位, 保证 KernelMatrix 里 append(embs, 1) 不触发重新分配。
+func cloneEmbedding(emb []float64) []float64 {
+	cloned := make([]float64, len(emb), len(emb)+1)
+	copy(cloned, emb)
+	return cloned
+}
+
 func NewDPPSort(config recconf.DPPSortConfig) *DPPSort {
 	hologres, err := holo.GetPostgres(config.DaoConf.HologresName)
 	if err != nil {
@@ -66,6 +75,10 @@ func NewDPPSort(config recconf.DPPSortConfig) *DPPSort {
 	if config.CacheTimeInMinutes > 0 {
 		cacheTime = time.Duration(config.CacheTimeInMinutes)
 	}
+	cacheSize := 500000
+	if config.CacheSize > 0 {
+		cacheSize = config.CacheSize
+	}
 	dpp := DPPSort{
 		db:                   hologres.DB,
 		tableName:            config.TableName,
@@ -74,7 +87,7 @@ func NewDPPSort(config recconf.DPPSortConfig) *DPPSort {
 		embeddingField:       config.EmbeddingColumn,
 		embSeparator:         config.EmbeddingSeparator,
 		alpha:                config.Alpha,
-		embCache:             cache.New(cache.WithMaximumSize(500000), cache.WithExpireAfterAccess(cacheTime*time.Minute)),
+		embCache:             cache.New(cache.WithMaximumSize(cacheSize), cache.WithExpireAfterAccess(cacheTime*time.Minute)),
 		lastTableSuffixParam: "",
 		embeddingHookNames:   config.EmbeddingHookNames,
 		normalizeEmb:         true,
@@ -191,7 +204,7 @@ func (s *DPPSort) loadEmbeddingCache(ctx *context.RecommendContext, items []*mod
 			absentItemIds = append(absentItemIds, string(item.Id))
 			itemMap[string(item.Id)] = item
 		} else {
-			item.Embedding = embI.([]float64)
+			item.Embedding = cloneEmbedding(embI.([]float64))
 			if embedSize == 0 {
 				embedSize = len(item.Embedding)
 			}
@@ -237,7 +250,7 @@ func (s *DPPSort) loadEmbeddingCache(ctx *context.RecommendContext, items []*mod
 			}
 			s.embCache.Put(itemID.String, vector)
 			if item, ok := itemMap[itemID.String]; ok {
-				item.Embedding = vector
+				item.Embedding = cloneEmbedding(vector)
 			} else {
 				return -1, errors.New("item id is not in map")
 			}

--- a/sort/ssd_sort.go
+++ b/sort/ssd_sort.go
@@ -58,6 +58,10 @@ func NewSSDSort(config recconf.SSDSortConfig) *SSDSort {
 	if config.CacheTimeInMinutes > 0 {
 		cacheTime = time.Duration(config.CacheTimeInMinutes)
 	}
+	cacheSize := 500000
+	if config.CacheSize > 0 {
+		cacheSize = config.CacheSize
+	}
 	ssd := SSDSort{
 		db:                   hologres.DB,
 		tableName:            config.TableName,
@@ -67,7 +71,7 @@ func NewSSDSort(config recconf.SSDSortConfig) *SSDSort {
 		embSeparator:         config.EmbeddingSeparator,
 		gamma:                0.25,
 		useSSDStar:           config.UseSSDStar,
-		embCache:             cache.New(cache.WithMaximumSize(500000), cache.WithExpireAfterAccess(cacheTime*time.Minute)),
+		embCache:             cache.New(cache.WithMaximumSize(cacheSize), cache.WithExpireAfterAccess(cacheTime*time.Minute)),
 		lastTableSuffixParam: "",
 		normalizeEmb:         true,
 		windowSize:           config.WindowSize,
@@ -202,7 +206,7 @@ func (s *SSDSort) loadEmbeddingCache(ctx *context.RecommendContext, items []*mod
 			absentItemIds = append(absentItemIds, string(item.Id))
 			itemMap[string(item.Id)] = item
 		} else {
-			item.Embedding = embI.([]float64)
+			item.Embedding = cloneEmbedding(embI.([]float64))
 			if embedSize == 0 {
 				embedSize = len(item.Embedding)
 			} else if embedSize != len(item.Embedding) {
@@ -261,7 +265,7 @@ func (s *SSDSort) loadEmbeddingCache(ctx *context.RecommendContext, items []*mod
 			}
 			s.embCache.Put(itemID.String, vector)
 			if item, ok := itemMap[itemID.String]; ok {
-				item.Embedding = vector
+				item.Embedding = cloneEmbedding(vector)
 			} else {
 				return errors.New("item id is not in map")
 			}


### PR DESCRIPTION
修复 DPPSort 和 SSDSort 每次重排计算都会直接覆盖缓存的向量，从而造成向量污染