### PR TITLE
fix: skip missing shopping evidence fields

### DIFF
--- a/service/recall/ha3_chat_search_params.go
+++ b/service/recall/ha3_chat_search_params.go
@@ -44,10 +44,14 @@ func (r *Ha3ChatRecall) attachToolParamEvidence(result *SearchGoodsResult, value
 		}
 		for i := range result.Hits {
 			hit := &result.Hits[i]
+			value, exists := hit.Properties[param.Field]
+			if !exists || value == nil {
+				continue
+			}
 			if hit.ConstraintEvidence == nil {
 				hit.ConstraintEvidence = make(map[string]interface{})
 			}
-			hit.ConstraintEvidence[param.Name] = hit.Properties[param.Field]
+			hit.ConstraintEvidence[param.Name] = value
 		}
 	}
 }


### PR DESCRIPTION
当商品返回结果缺少 ToolParam 对应字段或字段值为 nil 时，原实现会向模型发送 `constraint_evidence: {"style": null}`。现在跳过此类字段，仅在存在实际值时分配并写入 evidence；保留其他字段原值及已有证据。

对应 [PR #225 的 review 意见](https://github.com/alibaba/pairec/pull/225#discussion_r3977271834)。

验证：已执行 gofmt、git diff --check，并检查 nil map 读取及模型 payload 的证据省略条件。按约定未新增或运行测试。
