### PR TITLE
fix: log final OpenSearch DSL for shopping recall

### DIFF
--- a/service/aishopping/agent_loop.go
+++ b/service/aishopping/agent_loop.go
@@ -301,6 +301,10 @@ func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCa
 		req.Limit = fineRank.CandidateCount
 	}
 	req.FieldAware = fieldAware
+	req.LogRequest = func(dsl string) {
+		log.Info(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=opensearch_recall\tround=%d\tdsl=%s",
+			meta.requestId, meta.uid, meta.sessionId, round, dsl))
+	}
 	intent := sanitizeSearchIntent(req)
 	dispatchResult := toolDispatchResult{
 		isSearch: true,
@@ -311,8 +315,8 @@ func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCa
 	result, err := recall.Search(ctx, req)
 	recallCost := utils.CostTime(recallStart)
 	if err != nil {
-		log.Error(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=opensearch_recall\tround=%d\tkeywords=%s\toperator=%s\tlimit=%d\tcost=%d\terr=%v",
-			meta.requestId, meta.uid, meta.sessionId, round, compactJSON(req.Keywords), dispatchResult.operator, req.Limit, recallCost, err))
+		log.Error(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=opensearch_recall\tround=%d\tcost=%d\terr=%v",
+			meta.requestId, meta.uid, meta.sessionId, round, recallCost, err))
 		dispatchResult.content = fmt.Sprintf(`{"error":%q}`, err.Error())
 		dispatchResult.hasError = true
 		return dispatchResult
@@ -322,8 +326,6 @@ func dispatchTool(ctx context.Context, recall chatRecall, toolCall aichat.ToolCa
 		dispatchResult.hasError = true
 		return dispatchResult
 	}
-	log.Info(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=opensearch_recall\tround=%d\tkeywords=%s\toperator=%s\tlimit=%d\ttotal=%d\thits=%d\titemIds=%s\tcost=%d",
-		meta.requestId, meta.uid, meta.sessionId, round, compactJSON(req.Keywords), dispatchResult.operator, req.Limit, result.Total, len(result.Hits), compactJSON(searchResultItemIds(result)), recallCost))
 	dispatchResult.empty = len(result.Hits) == 0
 	if fineRank != nil {
 		if len(result.Hits) > 1 {

--- a/service/recall/ha3_chat_recall.go
+++ b/service/recall/ha3_chat_recall.go
@@ -34,8 +34,9 @@ type Ha3ChatRecall struct {
 
 type SearchGoodsRequest struct {
 	aichat.SearchGoodsParams
-	Limit      int  `json:"-"`
-	FieldAware bool `json:"-"`
+	Limit      int              `json:"-"`
+	FieldAware bool             `json:"-"`
+	LogRequest func(dsl string) `json:"-"`
 }
 
 type GoodsHit struct {
@@ -166,6 +167,9 @@ func (r *Ha3ChatRecall) searchField(ctx context.Context, field string, keywords 
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
+	}
+	if req.LogRequest != nil {
+		req.LogRequest(string(bodyBytes))
 	}
 	resp, err := r.client.Ha3Client.SearchRestWithContext(
 		ctx,


### PR DESCRIPTION
AI shopping 的 OpenSearch 召回日志原先只输出 keywords、operator 等参数，无法看到类目过滤、价格条件及打散配置。现在在最终 DSL 序列化完成、交给 HTTP SDK 前输出完整请求 JSON，保留 requestId、uid、session_id 和 round，移除原参数摘要日志。

每次零结果偏好降级和可重试 HTTP 请求都会记录对应 DSL；召回失败仍保留错误及耗时日志。检索逻辑和类目字段映射保持原样。

验证：`go build ./service/aishopping ./service/recall` 通过；仓库外临时探针对真实 dispatchTool → Recall → SDK 链路进行了 7 个场景、8 次回环 HTTP 请求验证，日志 DSL 与实际请求体逐字一致。未调用客户模型。变更仅包含两个 Go 源文件，没有新增单元测试或文档文件。
