### PR TITLE
fix: remove shopping keyword limits and return suggestion error details

### DIFF
--- a/algorithm/aichat/tool_schema.go
+++ b/algorithm/aichat/tool_schema.go
@@ -3,10 +3,8 @@ package aichat
 import "github.com/alibaba/pairec/v2/recconf"
 
 const (
-	SearchGoodsMaxKeywords          = 8
-	SearchGoodsMaxPreferredKeywords = 5
-	SuggestionMinLength             = 2
-	SuggestionMaxLength             = 80
+	SuggestionMinLength = 2
+	SuggestionMaxLength = 80
 )
 
 func SearchGoodsTool() Tool {
@@ -19,17 +17,14 @@ func FieldAwareSearchGoodsTool(conf *recconf.SearchGoodsConfig) Tool {
 			"type":     "array",
 			"items":    map[string]interface{}{"type": "string"},
 			"minItems": 1,
-			"maxItems": SearchGoodsMaxKeywords,
 		},
 		"preferred_keywords": map[string]interface{}{
-			"type":     "array",
-			"items":    map[string]interface{}{"type": "string"},
-			"maxItems": SearchGoodsMaxPreferredKeywords,
+			"type":  "array",
+			"items": map[string]interface{}{"type": "string"},
 		},
 		"exclude_keywords": map[string]interface{}{
-			"type":     "array",
-			"items":    map[string]interface{}{"type": "string"},
-			"maxItems": 5,
+			"type":  "array",
+			"items": map[string]interface{}{"type": "string"},
 		},
 		"min_price": map[string]interface{}{
 			"type":             "number",

--- a/service/aishopping/orchestrator.go
+++ b/service/aishopping/orchestrator.go
@@ -165,7 +165,7 @@ func (o *ChatSearchOrchestrator) Run(ctx context.Context, req *Request, writer *
 		if outcome.Err != nil {
 			log.Warning(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=suggestion\tstatus=error\tcode=%s\tretryable=%t\terr=%s",
 				req.RequestId, req.Uid, req.SessionId, outcome.Err.Code, outcome.Err.Retryable, compactLogError(outcome.Err.Cause)))
-			if err := writer.EmitSuggestionError(outcome.Err.Code, outcome.Err.PublicMessage(cfg.language), outcome.Err.Retryable); err != nil {
+			if err := writer.EmitSuggestionError(outcome.Err.Code, outcome.Err.Code, outcome.Err.Retryable); err != nil {
 				return err
 			}
 		} else {

--- a/service/aishopping/orchestrator.go
+++ b/service/aishopping/orchestrator.go
@@ -165,7 +165,7 @@ func (o *ChatSearchOrchestrator) Run(ctx context.Context, req *Request, writer *
 		if outcome.Err != nil {
 			log.Warning(fmt.Sprintf("requestId=%s\tuid=%s\tsession_id=%s\tmodule=AIShoppingChat\tphase=suggestion\tstatus=error\tcode=%s\tretryable=%t\terr=%s",
 				req.RequestId, req.Uid, req.SessionId, outcome.Err.Code, outcome.Err.Retryable, compactLogError(outcome.Err.Cause)))
-			if err := writer.EmitSuggestionError(outcome.Err.Code, outcome.Err.Code, outcome.Err.Retryable); err != nil {
+			if err := writer.EmitSuggestionError(outcome.Err.Code, outcome.Err.Error(), outcome.Err.Retryable); err != nil {
 				return err
 			}
 		} else {

--- a/service/recall/ha3_chat_multi_field.go
+++ b/service/recall/ha3_chat_multi_field.go
@@ -91,14 +91,8 @@ func isASCIIAlpha(char byte) bool {
 }
 
 func normalizeFieldAwareRequest(req SearchGoodsRequest) (SearchGoodsRequest, error) {
-	if len(req.Keywords) == 0 || len(req.Keywords) > maxSearchKeywordCount {
-		return req, fmt.Errorf("keywords must contain 1 to %d terms or phrases", maxSearchKeywordCount)
-	}
-	if len(req.PreferredKeywords) > maxSearchPreferredKeywordCount {
-		return req, fmt.Errorf("preferred_keywords must contain at most %d values", maxSearchPreferredKeywordCount)
-	}
-	if len(req.ExcludeKeywords) > 5 {
-		return req, fmt.Errorf("exclude_keywords must contain at most 5 values")
+	if len(req.Keywords) == 0 {
+		return req, fmt.Errorf("keywords must contain at least one term or phrase")
 	}
 
 	var err error

--- a/service/recall/ha3_chat_recall.go
+++ b/service/recall/ha3_chat_recall.go
@@ -19,10 +19,8 @@ import (
 )
 
 const (
-	maxSearchKeywordCount          = aichat.SearchGoodsMaxKeywords
-	maxSearchPreferredKeywordCount = aichat.SearchGoodsMaxPreferredKeywords
-	maxSearchKeywordRunes          = 64
-	fieldAwareSearchTimeout        = 2 * time.Second
+	maxSearchKeywordRunes   = 64
+	fieldAwareSearchTimeout = 2 * time.Second
 )
 
 type Ha3ChatRecall struct {
@@ -198,11 +196,7 @@ func (r *Ha3ChatRecall) buildFieldQueryExpr(field string, keywords []string, ope
 	if field == "" {
 		return "", fmt.Errorf("search field is empty")
 	}
-	keywordLimit := maxSearchKeywordCount
-	if r.fieldAwareEnabled() {
-		keywordLimit += maxSearchPreferredKeywordCount
-	}
-	keywords = normalizeKeywords(keywords, keywordLimit)
+	keywords = normalizeKeywords(keywords)
 	if len(keywords) == 0 {
 		return "", fmt.Errorf("keywords is empty")
 	}
@@ -210,19 +204,12 @@ func (r *Ha3ChatRecall) buildFieldQueryExpr(field string, keywords []string, ope
 	if strings.EqualFold(operator, "OR") {
 		sep = " | "
 	}
-	first, rest := keywords[0], keywords[1:]
-	pos := fmt.Sprintf("%s:'%s'", field, first)
-	for _, kw := range rest {
-		pos += sep + fmt.Sprintf("'%s'", kw)
-	}
-	excludes := normalizeKeywords(excludeKeywords, maxSearchKeywordCount)
+	pos := fmt.Sprintf("%s:'%s'", field, strings.Join(keywords, "'"+sep+"'"))
+	excludes := normalizeKeywords(excludeKeywords)
 	if len(excludes) == 0 {
 		return pos, nil
 	}
-	neg := fmt.Sprintf("%s:'%s'", r.conf.DefaultField, excludes[0])
-	for _, kw := range excludes[1:] {
-		neg += " | " + fmt.Sprintf("'%s'", kw)
-	}
+	neg := fmt.Sprintf("%s:'%s'", r.conf.DefaultField, strings.Join(excludes, "' | '"))
 	return fmt.Sprintf("(%s) ANDNOT (%s)", pos, neg), nil
 }
 
@@ -240,15 +227,12 @@ func (r *Ha3ChatRecall) buildFilterExpr(req SearchGoodsRequest) string {
 	return strings.Join(conds, " AND ")
 }
 
-func normalizeKeywords(keywords []string, limit int) []string {
+func normalizeKeywords(keywords []string) []string {
 	out := make([]string, 0, len(keywords))
 	for _, keyword := range keywords {
 		keyword = sanitizeSearchKeyword(keyword)
 		if keyword != "" {
 			out = append(out, keyword)
-			if len(out) >= limit {
-				break
-			}
 		}
 	}
 	return out

--- a/service/searchsuggestion/errors.go
+++ b/service/searchsuggestion/errors.go
@@ -47,15 +47,8 @@ func (e *Error) Unwrap() error {
 	return e.Cause
 }
 
-func (e *Error) PublicMessage(language string) string {
-	switch language {
-	case "zh":
-		return "追问建议暂时不可用"
-	case "ar":
-		return "اقتراحات البحث غير متاحة مؤقتًا"
-	default:
-		return "Search suggestions are temporarily unavailable"
-	}
+func (e *Error) PublicMessage(_ string) string {
+	return "Search suggestions are temporarily unavailable"
 }
 
 type Outcome struct {

--- a/service/searchsuggestion/errors.go
+++ b/service/searchsuggestion/errors.go
@@ -47,10 +47,6 @@ func (e *Error) Unwrap() error {
 	return e.Cause
 }
 
-func (e *Error) PublicMessage(_ string) string {
-	return "Search suggestions are temporarily unavailable"
-}
-
 type Outcome struct {
 	Suggestions []string
 	Err         *Error

--- a/web/search_suggestion_controller.go
+++ b/web/search_suggestion_controller.go
@@ -104,7 +104,7 @@ func (c *SearchSuggestionController) Process(w http.ResponseWriter, r *http.Requ
 func (c *SearchSuggestionController) writeSuggestionError(w http.ResponseWriter, suggestionErr *searchsuggestion.Error) {
 	log.Warning(fmt.Sprintf("requestId=%s\tmodule=SearchSuggestion\tevent=end\tstatus=error\tcode=%s\tretryable=%t\terr=%v\tcost=%d",
 		c.RequestId, suggestionErr.Code, suggestionErr.Retryable, suggestionErr.Cause, time.Since(c.Start).Milliseconds()))
-	c.writeResponse(w, SERVER_ERROR_CODE, suggestionErr.Code, nil)
+	c.writeResponse(w, SERVER_ERROR_CODE, suggestionErr.Error(), nil)
 }
 
 func (c *SearchSuggestionController) writeResponse(w http.ResponseWriter, code int, message string, suggestions []string) {

--- a/web/search_suggestion_controller.go
+++ b/web/search_suggestion_controller.go
@@ -104,7 +104,7 @@ func (c *SearchSuggestionController) Process(w http.ResponseWriter, r *http.Requ
 func (c *SearchSuggestionController) writeSuggestionError(w http.ResponseWriter, suggestionErr *searchsuggestion.Error) {
 	log.Warning(fmt.Sprintf("requestId=%s\tmodule=SearchSuggestion\tevent=end\tstatus=error\tcode=%s\tretryable=%t\terr=%v\tcost=%d",
 		c.RequestId, suggestionErr.Code, suggestionErr.Retryable, suggestionErr.Cause, time.Since(c.Start).Milliseconds()))
-	c.writeResponse(w, SERVER_ERROR_CODE, suggestionErr.PublicMessage(c.param.Language), nil)
+	c.writeResponse(w, SERVER_ERROR_CODE, suggestionErr.Code, nil)
 }
 
 func (c *SearchSuggestionController) writeResponse(w http.ResponseWriter, code int, message string, suggestions []string) {


### PR DESCRIPTION
本 PR 基于 #225 的 `feat/aishopping-field-aware-fallback` 分支。

移除 `keywords`、`preferred_keywords`、`exclude_keywords` 在工具 Schema、请求校验和 HA3 查询构造中的数量上限，避免尾部查询条件被静默丢弃。不新增配置参数；保留主词非空、清洗去重、单词字符处理和偏好词降级逻辑。查询拼接使用 `strings.Join`。

删除建议失败的固定提示和 `PublicMessage`；HTTP `msg`、SSE `suggestions_error.message` 使用现有 `Error()` 返回错误码及底层错误原因。例如超时返回 `suggestion_timeout: context deadline exceeded`，没有 Cause 时仅返回错误码。SSE 的 `code` 和 `retryable` 字段、成功响应和原有 HTTP 状态行为保持。

验证：

- `go build ./...` 通过。
- 临时 Go overlay 回归通过：Schema、Planner 参数解析、1,000 个主词、完整 HA3 HTTP 请求、两种 field-aware 配置下的偏好降级/空结果/后端错误。测试文件未加入 PR。
- 错误详情增量回归通过：HTTP 超时、缺少语言 prompt、模型失败及无 Cause 四个场景；SSE 验证详细消息序列化以及 code/retryable 字段保持。
- 本次 Web 现有测试通过；此前关键词修改的 recconf、FeatureStore 现有测试通过。
- Standards / Spec 两路 review 均无待修复发现。

现有 `service/recall.TestMultibizRecall` 因传入 nil 导致空指针失败，已在未修改的基线 `4bd2297` 复现；不是本次新增回归。因此不宣称整个现有测试集全部通过。
